### PR TITLE
add names to e_lines and e_lines_3d and fix a bug of e_map_3d_custom

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -1019,6 +1019,8 @@ e_gauge_ <- e_gauge
 #' @param coord_system Coordinate system to use, such as \code{cartesian3D}, or \code{globe}.
 #' @param y,z Coordinates of lines.
 #' @param source_lon,source_lat,target_lon,target_lat coordinates.
+#' @param source_name,target_name names.
+#' @param value  values.
 #' @param rm_x,rm_y Whether to remove x and y axis, defaults to \code{TRUE}.
 #' 
 #' @examples 
@@ -1075,16 +1077,26 @@ e_gauge_ <- e_gauge
 #' 
 #' @rdname line3D
 #' @export
-e_lines_3d <- function(e, source_lon, source_lat, target_lon, target_lat, name = NULL, 
+e_lines_3d <- function(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name, value, name = NULL, 
                        coord_system = "globe", rm_x = TRUE, rm_y = TRUE, ...){
   if(missing(e))
     stop("must pass e", call. = FALSE)
   
   if(missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon))
     stop("missing coordinates", call. = FALSE)
+  if(missing(source_name))
+    source_name <- NULL
+  
+  if(missing(target_name))
+    target_name <- NULL
+  
+  if(missing(value))
+    value <- NULL
   
   e_lines_3d_(e, deparse(substitute(source_lon)), deparse(substitute(source_lat)), 
               deparse(substitute(target_lon)), deparse(substitute(target_lat)), 
+              deparse(substitute(source_name)), deparse(substitute(target_name)),
+              deparse(substitute(value)),
               name, coord_system, rm_x, rm_y, ...)
 }
 
@@ -1225,6 +1237,15 @@ e_lines <- function(e, source_lon, source_lat, target_lon, target_lat, source_na
   
   if(missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon))
     stop("missing coordinates", call. = FALSE)
+  
+  if(missing(source_name))
+    source_name <- NULL
+  
+  if(missing(target_name))
+    target_name <- NULL
+  
+  if(missing(value))
+    value <- NULL
   
   e_lines_(e, deparse(substitute(source_lon)), deparse(substitute(source_lat)), 
            deparse(substitute(target_lon)), deparse(substitute(target_lat)),

--- a/R/add.R
+++ b/R/add.R
@@ -1183,6 +1183,8 @@ e_bar_3d <- function(e, y, z, bind, coord_system = "cartesian3D", name = NULL,
 #' 
 #' @inheritParams e_bar
 #' @param source_lon,source_lat,target_lon,target_lat coordinates.
+#' @param source_name,target_name names
+#' @param value values
 #' @param coord_system Coordinate system to use, one of \code{geo}, or \code{cartesian2d}.
 #' @param rm_x,rm_y Whether to remove x and y axis, defaults to \code{TRUE}.
 #' 
@@ -1200,15 +1202,23 @@ e_bar_3d <- function(e, y, z, bind, coord_system = "cartesian3D", name = NULL,
 #'     start_lat, 
 #'     end_lon, 
 #'     end_lat,
+#'     airport1,
+#'     airport2,
+#'     cnt,
 #'     name = "flights",
 #'     lineStyle = list(normal = list(curveness = 0.3))
-#'    )
+#'   )%>%e_tooltip(trigger="item",
+#'   formatter = htmlwidgets::JS("
+#'       function(params){
+#'       return(params.seriesName +'<br />' + params.data.source_name + ' -> ' + params.data.target_name + ':'+params.value)
+#'       }
+#'    "))
 #' 
 #' @seealso \href{https://ecomfe.github.io/echarts-doc/public/en/option.html#series-lines}{Additional arguments}
 #' 
 #' @rdname e_lines
 #' @export
-e_lines <- function(e, source_lon, source_lat, target_lon, target_lat, coord_system = "geo", name = NULL, 
+e_lines <- function(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name ,value, coord_system = "geo", name = NULL, 
                     rm_x = TRUE, rm_y = TRUE, ...){
   if(missing(e))
     stop("must pass e", call. = FALSE)
@@ -1217,7 +1227,9 @@ e_lines <- function(e, source_lon, source_lat, target_lon, target_lat, coord_sys
     stop("missing coordinates", call. = FALSE)
   
   e_lines_(e, deparse(substitute(source_lon)), deparse(substitute(source_lat)), 
-           deparse(substitute(target_lon)), deparse(substitute(target_lat)), 
+           deparse(substitute(target_lon)), deparse(substitute(target_lat)),
+           deparse(substitute(source_name)), deparse(substitute(target_name)),
+           deparse(substitute(value)),
            coord_system, name, rm_x, rm_y, ...)
 }
 

--- a/R/add_.R
+++ b/R/add_.R
@@ -931,13 +931,22 @@ e_bar_3d_ <- function(e, y, z, bind = NULL, coord_system = "cartesian3D", name =
 
 #' @rdname e_lines
 #' @export
-e_lines_ <- function(e, source_lon, source_lat, target_lon, target_lat, coord_system = "geo", name = NULL, 
+e_lines_ <- function(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name ,value, coord_system = "geo", name = NULL, 
                     rm_x = TRUE, rm_y = TRUE, ...){
   if(missing(e))
     stop("must pass e", call. = FALSE)
   
   if(missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon))
     stop("missing coordinates", call. = FALSE)
+  
+  if(missing(source_name))
+    source_name <- NULL
+  
+  if(missing(target_name))
+    target_name <- NULL
+  
+  if(missing(value))
+    value <- NULL
   
   # remove axis
   e <- .rm_axis(e, rm_x, "x")
@@ -948,7 +957,7 @@ e_lines_ <- function(e, source_lon, source_lat, target_lon, target_lat, coord_sy
     
     nm <- .name_it(e, NULL, name, i)
     
-    data <- .map_lines(e, source_lon, source_lat, target_lon, target_lat, i)
+    data <- .map_lines(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name, value, i)
     
     e.serie <- list(
       name = nm,

--- a/R/add_.R
+++ b/R/add_.R
@@ -785,7 +785,7 @@ e_tree_ <- function(e, parent, child, rm_x = TRUE, rm_y = TRUE, ...){
 
 #' @rdname line3D
 #' @export
-e_lines_3d_ <- function(e, source_lon, source_lat, target_lon, target_lat, name = NULL, coord_system = "globe",
+e_lines_3d_ <- function(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name, value, name = NULL, coord_system = "globe",
                         rm_x = TRUE, rm_y = TRUE, ...){
   if(missing(e))
     stop("must pass e", call. = FALSE)
@@ -793,13 +793,22 @@ e_lines_3d_ <- function(e, source_lon, source_lat, target_lon, target_lat, name 
   if(missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon))
     stop("missing coordinates", call. = FALSE)
   
+  if(missing(source_name))
+    source_name <- NULL
+  
+  if(missing(target_name))
+    target_name <- NULL
+  
+  if(missing(value))
+    value <- NULL
+  
   # remove axis
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
   
   for(i in 1:length(e$x$data)){
     
-    data <- .map_lines(e, source_lon, source_lat, target_lon, target_lat, i)
+    data <- .map_lines(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name, value, i=i)
     
     serie <- list(
       type = "lines3D",
@@ -938,7 +947,6 @@ e_lines_ <- function(e, source_lon, source_lat, target_lon, target_lat, source_n
   
   if(missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon))
     stop("missing coordinates", call. = FALSE)
-  
   if(missing(source_name))
     source_name <- NULL
   

--- a/R/map.R
+++ b/R/map.R
@@ -165,8 +165,8 @@ e_map_3d_custom <- function(e, id, value, height, map = NULL, name = NULL, rm_x 
   if(missing(id) || missing(value) || missing(height))
     stop("must pass id, value, and height", call. = FALSE)
   
-  if(is.null(map) && length(e$x$mapName))
-    map <- unlist(e$x$mapName)
+  if(is.null(map) && length(e$x$registerMap[[1]]$mapName))
+    map <- unlist(e$x$registerMap[[1]]$mapName)
   else
     stop("not map registered, see e_map_register", call. = FALSE)
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -417,19 +417,31 @@ globalVariables(c("e", ".", "acc", "epoch", "loss", "size", "val_acc", "val_loss
   paste0(axis, "Axis3D")
 }
 
-.map_lines <- function(e, source.lon, source.lat, target.lon, target.lat, i){
+.map_lines <- function(e, source.lon, source.lat, target.lon, target.lat, source.name, target.name, value, i){
   
-  e$x$data[[i]] %>% 
+  data <- e$x$data[[i]] %>% 
     dplyr::select_(
       source.lon, source.lat, target.lon, target.lat
     ) %>% 
     apply(., 1, function(x){
       x <- unname(x)
       list(
-        c(x[1], x[2]),
-        c(x[3], x[4])
+        coords = list(
+          c(x[1], x[2]),
+          c(x[3], x[4])
+        )
       )
     }) 
+  if (!is.null(source.name)){
+    data <- .add_bind2(e,data,source.name,col="source_name",i)
+  }
+  if (!is.null(target.name)){
+    data <- .add_bind2(e,data,target.name,col="target_name",i)
+  }
+  if (!is.null(value)){
+    data <- .add_bind2(e,data,value,col="value",i)
+  }
+  data
 }
 
 .build_cartesian3D <- function(e, ..., i = 1){

--- a/man/e_lines.Rd
+++ b/man/e_lines.Rd
@@ -5,16 +5,22 @@
 \alias{e_lines_}
 \title{Lines}
 \usage{
-e_lines(e, source_lon, source_lat, target_lon, target_lat,
-  coord_system = "geo", name = NULL, rm_x = TRUE, rm_y = TRUE, ...)
+e_lines(e, source_lon, source_lat, target_lon, target_lat, source_name,
+  target_name, value, coord_system = "geo", name = NULL, rm_x = TRUE,
+  rm_y = TRUE, ...)
 
-e_lines_(e, source_lon, source_lat, target_lon, target_lat,
-  coord_system = "geo", name = NULL, rm_x = TRUE, rm_y = TRUE, ...)
+e_lines_(e, source_lon, source_lat, target_lon, target_lat, source_name,
+  target_name, value, coord_system = "geo", name = NULL, rm_x = TRUE,
+  rm_y = TRUE, ...)
 }
 \arguments{
 \item{e}{An \code{echarts4r} object as returned by \code{\link{e_charts}}.}
 
 \item{source_lon, source_lat, target_lon, target_lat}{coordinates.}
+
+\item{source_name, target_name}{names}
+
+\item{value}{values}
 
 \item{coord_system}{Coordinate system to use, one of \code{geo}, or \code{cartesian2d}.}
 
@@ -41,9 +47,17 @@ flights \%>\%
     start_lat, 
     end_lon, 
     end_lat,
+    airport1,
+    airport2,
+    cnt,
     name = "flights",
     lineStyle = list(normal = list(curveness = 0.3))
-   )
+  )\%>\%e_tooltip(trigger="item",
+  formatter = htmlwidgets::JS("
+      function(params){
+      return(params.seriesName +'<br />' + params.data.source_name + ' -> ' + params.data.target_name + ':'+params.value)
+      }
+   "))
 
 }
 \seealso{

--- a/man/e_map_register.Rd
+++ b/man/e_map_register.Rd
@@ -25,7 +25,7 @@ USArrests \%>\%
   e_charts(states) \%>\%
   e_map_register("USA", json) \%>\%
   e_map(Murder, map = "USA") \%>\% 
-  e_visual_map(min = 0, max = 18)
+  e_visual_map(Murder)
 }
 
 }

--- a/man/line3D.Rd
+++ b/man/line3D.Rd
@@ -7,16 +7,16 @@
 \alias{e_line_3d_}
 \title{Lines 3D}
 \usage{
-e_lines_3d(e, source_lon, source_lat, target_lon, target_lat,
-  name = NULL, coord_system = "globe", rm_x = TRUE, rm_y = TRUE,
-  ...)
+e_lines_3d(e, source_lon, source_lat, target_lon, target_lat, source_name,
+  target_name, value, name = NULL, coord_system = "globe",
+  rm_x = TRUE, rm_y = TRUE, ...)
 
 e_line_3d(e, y, z, name = NULL, coord_system = NULL, rm_x = TRUE,
   rm_y = TRUE, ...)
 
-e_lines_3d_(e, source_lon, source_lat, target_lon, target_lat,
-  name = NULL, coord_system = "globe", rm_x = TRUE, rm_y = TRUE,
-  ...)
+e_lines_3d_(e, source_lon, source_lat, target_lon, target_lat, source_name,
+  target_name, value, name = NULL, coord_system = "globe",
+  rm_x = TRUE, rm_y = TRUE, ...)
 
 e_line_3d_(e, y, z, name = NULL, coord_system = NULL, rm_x = TRUE,
   rm_y = TRUE, ...)
@@ -25,6 +25,10 @@ e_line_3d_(e, y, z, name = NULL, coord_system = NULL, rm_x = TRUE,
 \item{e}{An \code{echarts4r} object as returned by \code{\link{e_charts}}.}
 
 \item{source_lon, source_lat, target_lon, target_lat}{coordinates.}
+
+\item{source_name, target_name}{names.}
+
+\item{value}{values.}
 
 \item{name}{name of the serie.}
 


### PR DESCRIPTION
1. add names and values into e_lines and e_lines_3d, so you can modify the formatter of the line tooltip.


2. Since you changed the code of `e_map_register` , the function `e_map_register` can not run properly
because the `e$x$mapName` is no longer exist.