### PR TITLE
e_mark_point() use exact matching for the serie param

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Bar chart's `bind` argument has been fixed.
 - `e_tooltip_choro_formatter` tooltip formatter for choropleth maps added, thanks to [Artem](https://github.com/artemklevtsov).
 - Tooltip formatters correctly identify locale on UNIX systems, thanks to [Artem](https://github.com/artemklevtsov).
+- `e_mark_point()`, `e_mark_line()` and `e_mark_area()` no longer use `grep()`, which means the serie will only be matched with the exact same name. Thanks @shrektan for the reporting and PR (#80, #81).
 
 # echarts4r 0.2.2
 

--- a/R/mark.R
+++ b/R/mark.R
@@ -3,7 +3,7 @@
 #' Mark points and lines.
 #' 
 #' @inheritParams e_bar
-#' @param serie Serie or vector of series to mark on passed to \code{\link{grep}}, defaults to all series.
+#' @param serie Serie or vector of series to mark on, defaults to all series.
 #' @param data Placement.
 #' 
 #' @examples 

--- a/R/utils.R
+++ b/R/utils.R
@@ -548,10 +548,8 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
 }
 
 .get_index <- function(e, serie){
-  serie <- paste0(serie, collapse = "|")
-  purrr::map(e$x$opts$series, "name") %>% 
-    unlist() %>% 
-    grep(serie, .)
+  series <- purrr::map(e$x$opts$series, "name") %>% unlist()
+  purrr::map(serie, ~which(series == .)) %>% unlist() %>% unique()
 }
 
 .add_indicators <- function(e, r.index, max){

--- a/man/mark.Rd
+++ b/man/mark.Rd
@@ -15,7 +15,7 @@ e_mark_area(e, serie = NULL, data = NULL, ...)
 \arguments{
 \item{e}{An \code{echarts4r} object as returned by \code{\link{e_charts}}.}
 
-\item{serie}{Serie or vector of series to mark on passed to \code{\link{grep}}, defaults to all series.}
+\item{serie}{Serie or vector of series to mark on, defaults to all series.}
 
 \item{data}{Placement.}
 


### PR DESCRIPTION
Closes #80 

After the PR, the below two examples work as expected.

```r
library(echarts4r)
x <- data.frame(a = 1:10, b = 1:10)
e_chart(x, 'a') %>%
  e_line('b', name = 'aa(bb)', smooth = TRUE, symbol = 'none') %>%
  e_mark_point('aa(bb)', data = list(xAxis = 5, yAxis = 5, value = 5))
```

```r
library(echarts4r)
x <- data.frame(a = 1:10, b = 1:10, c = 1:20)
e_chart(x, 'a') %>%
  e_line('b', name = 'abcdefg', smooth = TRUE, symbol = 'none') %>%
  e_line('c', name = 'abcd', smooth = TRUE, symbol = 'none') %>%
  e_mark_point('abcd', data = list(xAxis = 5, yAxis = 5, value = 5))
```