### PR TITLE
Fix e_sankey_

### DIFF
--- a/R/add_.R
+++ b/R/add_.R
@@ -760,7 +760,7 @@ e_sankey_ <- function(e, source, target, value, layout = "none", rm_x = TRUE, rm
   serie <- list(
     type = "sankey",
     layout = layout,
-    nodes = nodes,
+    data = nodes,
     links = edges,
     ...
   )


### PR DESCRIPTION
According with [example](https://echarts.apache.org/examples/en/editor.html?c=sankey-simple) option name should be `data` instead `nodes`. Now it's not correct (see [example](https://jsfiddle.net/artemklevtsov/0ktwmh4r/6/#&togetherjs=wgrhfcRnCw)): nodes can not be dragged.
Also `layout` seems to be renamed to `orient`.
API doc ref: https://echarts.apache.org/en/option.html#series-sankey