### PR TITLE
correction of e_radar legend

### DIFF
--- a/R/add_.R
+++ b/R/add_.R
@@ -647,6 +647,9 @@ e_radar_ <- function(e, serie, max = 100, name = NULL, legend = TRUE,
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
   
+  if(is.null(name)) # defaults to column name
+    name <- serie
+  
   # build JSON data
   .get_data(e, serie) -> vector
   


### PR DESCRIPTION
These two lines were (supposingly) removed by mistake in the previous commit ( 847d741 ). Without them, there are no legend when the `name` argument is empty in `e_radar_()`.