### PR TITLE
fix: set default z Index of error bar

### DIFF
--- a/R/add_.R
+++ b/R/add_.R
@@ -2070,6 +2070,9 @@ e_error_bar_ <- function(e, lower, upper, name = NULL, legend = TRUE, y_index = 
   if(missing(lower) || missing(upper))
     stop("must pass lower, or upper", call. = FALSE)
   
+  args <- list(...)
+  names(args) <- names(args)
+  
   for(i in 1:length(e$x$data)){
     
     .build_data2(e$x$data[[i]], e$x$mapping$x, lower, upper) -> vector
@@ -2103,6 +2106,7 @@ e_error_bar_ <- function(e, lower, upper, name = NULL, legend = TRUE, y_index = 
         type = "custom",
         yAxisIndex = y_index,
         xAxisIndex = x_index,
+        z = ifelse("z" %in% names(args), args$z, 3),
         coordinateSystem = coord_system,
         itemStyle = list(
           normal = list(
@@ -2141,6 +2145,7 @@ e_error_bar_ <- function(e, lower, upper, name = NULL, legend = TRUE, y_index = 
       type = "custom",
       yAxisIndex = y_index,
       xAxisIndex = x_index,
+      z = ifelse("z" %in% names(args), args$z, 3),
       coordinateSystem = coord_system,
       itemStyle = list(
         normal = list(


### PR DESCRIPTION
In the [docs page of error bars](https://echarts4r.john-coene.com/articles/stats.html#error-bars), the error bar is under the bar plot, although it can be set by passing `z = 3`, provide a default value would be better.

If the `z` argument is pass in, using the `z` provided by user, otherwise using the default value `z = 3`.

## Test

```r
df <- data.frame(
  x = factor(c(1, 2)),
  y = c(1, 5),
  upper = c(1.1, 5.3),
  lower = c(0.8, 4.6)
)

# default z = 3, error bar on the top layer
df %>% 
  e_charts(x) %>% 
  e_bar(y) %>% 
  e_error_bar(lower, upper)

# set z = 1, error bar is under the bar layer, useless but available. 
df %>% 
  e_charts(x) %>% 
  e_bar(y) %>% 
  e_error_bar(lower, upper, z = 1)

# timeline
df <- data.frame(
  x = factor(c(1, 1, 2, 2)),
  y = c(1, 5, 3, 4),
  step = factor(c(1, 2, 1, 2)),
  upper = c(1.1, 5.3, 3.3, 4.2),
  lower = c(0.8, 4.6, 2.4, 3.6)
)

# default z = 3, error bar on the top layer
df %>% 
  group_by(step) %>% 
  e_charts(x, timeline = TRUE) %>% 
  e_bar(y) %>% 
  e_error_bar(lower, upper)

# set z = 1, error bar is under the bar layer, useless but available. 
df %>% 
  group_by(step) %>% 
  e_charts(x, timeline = TRUE) %>% 
  e_bar(y) %>% 
  e_error_bar(lower, upper, z = 1)
```