### PR TITLE
fix: #93 remove default column name of `e_scatter_3d`

### DIFF
--- a/R/add_.R
+++ b/R/add_.R
@@ -1530,9 +1530,6 @@ e_scatter_3d_ <- function(e, y, z, color = NULL, size = NULL, bind = NULL, coord
   
   if(missing(y) || missing(z))
     stop("must pass y and z", call. = FALSE)
-
-  if(is.null(name)) # defaults to column name
-    name <- z
   
   # remove axis
   e <- .rm_axis(e, rm_x, "x")


### PR DESCRIPTION
When set the default name to `z`, in the iteration of setting group name, the name will always be `z`, so the `group_by` will not work.

If set the default name here, in the iteration part:
```r
    if(!e$x$tl){
      
      nm <- .name_it(e, NULL, name, i)
      e_serie$name <- nm
      
      e_serie <- append(e_serie, e_data)
      
      e$x$opts$series <- append(e$x$opts$series, list(e_serie))
      
    } else {
      e$x$opts$options[[i]]$series <- append(e$x$opts$options[[i]]$series, list(e_data))
    }
```
`name` is equals to `z`, so the `nm` will always be `z`, `e_serie$name` always the same, too.

I have tested the examples of `e_scatter_3d`, and it seems that this change is not going to bring some side effect.
Also test the example in #93:

```r
library(echarts4r)

iris %>% 
  group_by(Species) %>%
  e_charts(Sepal.Length) %>%
  e_scatter_3d(Sepal.Width, Petal.Length)
```

![image](https://user-images.githubusercontent.com/20528423/95228313-2366d800-083a-11eb-9246-e1c98e76551b.png)

It seems to be fine.