### PR TITLE
fix: #204 Fix quotation in LICENSE.md and Bug in the #199

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,55 +8,55 @@ _&lt;<http://www.apache.org/licenses/>&gt;_
 
 #### 1. Definitions
 
-â€œLicenseâ€ shall mean the terms and conditions for use, reproduction, and
+**"License"** shall mean the terms and conditions for use, reproduction, and
 distribution as defined by Sections 1 through 9 of this document.
 
-â€œLicensorâ€ shall mean the copyright owner or entity authorized by the copyright
+**"Licensor"** shall mean the copyright owner or entity authorized by the copyright
 owner that is granting the License.
 
-â€œLegal Entityâ€ shall mean the union of the acting entity and all other entities
+**"Legal Entity"** shall mean the union of the acting entity and all other entities
 that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, â€œcontrolâ€ means **(i)** the power, direct or
+For the purposes of this definition, **"control"** means **(i)** the power, direct or
 indirect, to cause the direction or management of such entity, whether by
 contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
 outstanding shares, or **(iii)** beneficial ownership of such entity.
 
-â€œYouâ€ (or â€œYourâ€) shall mean an individual or Legal Entity exercising
+**"You"** (or **"Your"**) shall mean an individual or Legal Entity exercising
 permissions granted by this License.
 
-â€œSourceâ€ form shall mean the preferred form for making modifications, including
+**"Source"** form shall mean the preferred form for making modifications, including
 but not limited to software source code, documentation source, and configuration
 files.
 
-â€œObjectâ€ form shall mean any form resulting from mechanical transformation or
+**"Object"** form shall mean any form resulting from mechanical transformation or
 translation of a Source form, including but not limited to compiled object code,
 generated documentation, and conversions to other media types.
 
-â€œWorkâ€ shall mean the work of authorship, whether in Source or Object form, made
+**"Work"** shall mean the work of authorship, whether in Source or Object form, made
 available under the License, as indicated by a copyright notice that is included
 in or attached to the work (an example is provided in the Appendix below).
 
-â€œDerivative Worksâ€ shall mean any work, whether in Source or Object form, that
+**"Derivative Works"** shall mean any work, whether in Source or Object form, that
 is based on (or derived from) the Work and for which the editorial revisions,
 annotations, elaborations, or other modifications represent, as a whole, an
 original work of authorship. For the purposes of this License, Derivative Works
 shall not include works that remain separable from, or merely link (or bind by
 name) to the interfaces of, the Work and Derivative Works thereof.
 
-â€œContributionâ€ shall mean any work of authorship, including the original version
+**"Contribution"** shall mean any work of authorship, including the original version
 of the Work and any modifications or additions to that Work or Derivative Works
 thereof, that is intentionally submitted to Licensor for inclusion in the Work
 by the copyright owner or by an individual or Legal Entity authorized to submit
 on behalf of the copyright owner. For the purposes of this definition,
-â€œsubmittedâ€ means any form of electronic, verbal, or written communication sent
+**"submitted"** means any form of electronic, verbal, or written communication sent
 to the Licensor or its representatives, including but not limited to
 communication on electronic mailing lists, source code control systems, and
 issue tracking systems that are managed by, or on behalf of, the Licensor for
 the purpose of discussing and improving the Work, but excluding communication
 that is conspicuously marked or otherwise designated in writing by the copyright
-owner as â€œNot a Contribution.â€
+owner as **"Not a Contribution."**
 
-â€œContributorâ€ shall mean Licensor and any individual or Legal Entity on behalf
+**"Contributor"** shall mean Licensor and any individual or Legal Entity on behalf
 of whom a Contribution has been received by Licensor and subsequently
 incorporated within the Work.
 
@@ -97,7 +97,7 @@ changed the files; and
 all copyright, patent, trademark, and attribution notices from the Source form
 of the Work, excluding those notices that do not pertain to any part of the
 Derivative Works; and
-* **(d)** If the Work includes a â€œNOTICEâ€ text file as part of its distribution, then any
+* **(d)** If the Work includes a **"NOTICE"** text file as part of its distribution, then any
 Derivative Works that You distribute must include a readable copy of the
 attribution notices contained within such NOTICE file, excluding those notices
 that do not pertain to any part of the Derivative Works, in at least one of the
@@ -136,7 +136,7 @@ reproducing the content of the NOTICE file.
 #### 7. Disclaimer of Warranty
 
 Unless required by applicable law or agreed to in writing, Licensor provides the
-Work (and each Contributor provides its Contributions) on an â€œAS ISâ€ BASIS,
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
 including, without limitation, any warranties or conditions of TITLE,
 NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
@@ -176,7 +176,7 @@ notice, with the fields enclosed by brackets `[]` replaced with your own
 identifying information. (Don't include the brackets!) The text should be
 enclosed in the appropriate comment syntax for the file format. We also
 recommend that a file or class name and description of purpose be included on
-the same â€œprinted pageâ€ as the copyright notice for easier identification within
+the same "printed page" as the copyright notice for easier identification within
 third-party archives.
 
     Copyright 2018 John Coene

--- a/inst/htmlwidgets/echarts4r.js
+++ b/inst/htmlwidgets/echarts4r.js
@@ -10,22 +10,22 @@ HTMLWidgets.widget({
 
     var chart,opts;
 
-    const evalFun = (originalObject) => {
-      let object = Object.assign({}, originalObject);
-      Object.keys(object).forEach((key) => {
-        if (object[key] !== null) {
-          if (typeof object[key] === 'object') {
-            evalFun(object[key]);
+    const evalFun = (sourceOpts) => {
+      let opts = Object.assign({}, sourceOpts);
+      Object.keys(opts).forEach((key) => {
+        if (opts[key] !== null) {
+          if (typeof opts[key] === 'object') {
+            evalFun(opts[key]);
             return;
           }
-          if (typeof object[key] === 'string') {
+          if (typeof opts[key] === 'string') {
             try {
-              object[key] = eval('(' + object[key] + ')');
+              opts[key] = eval('(' + opts[key] + ')');
             } catch { }
           }
         }
       });
-      return(object);
+      return(opts);
     }
     
     return {

--- a/inst/htmlwidgets/echarts4r.js
+++ b/inst/htmlwidgets/echarts4r.js
@@ -10,7 +10,8 @@ HTMLWidgets.widget({
 
     var chart,opts;
 
-    const evalFun = (object) => {
+    const evalFun = (originalObject) => {
+      let object = Object.assign({}, originalObject);
       Object.keys(object).forEach((key) => {
         if (object[key] !== null) {
           if (typeof object[key] === 'object') {


### PR DESCRIPTION
I'm so sorry about submit two unrelated commits in one PR (forgetting to switch the branch)

In 1a9d63f , Just update the quotation in license file.
Ref: http://www.apache.org/licenses/LICENSE-2.0

---

In d289a0b , Fix the problem cause be `evalFun()`

When I using the dev version to reproduce the demo in #153, the bar seems to be drawn from the index `1`. 
```r
df <- data.frame(
  x = factor(c(1, 2)),
  y = c(1, 5),
  upper = c(1.1, 5.3),
  lower = c(0.8, 4.6)
)

df %>%
  e_charts(x) %>%
  e_bar(y)
```
![image](https://user-images.githubusercontent.com/20528423/95284687-bd11a200-0899-11eb-9916-480f95301fa6.png)

I have check the options before and after `evalFun()` conversion, it seems the results are identical. I can not figure out where is the problem but after d289a0b the bug have been solved.

![image](https://user-images.githubusercontent.com/20528423/95284743-e92d2300-0899-11eb-8c49-3ae432972379.png)
