### PR TITLE
fix: #79 `e_tooltip_item_formatter` work with `e_flip_coords`

### DIFF
--- a/R/opts.R
+++ b/R/opts.R
@@ -211,9 +211,13 @@ e_tooltip_item_formatter <- function(style = c("decimal", "percent", "currency")
 
   tip <- htmlwidgets::JS(sprintf("function(params, ticket, callback) {
         var fmt = new Intl.NumberFormat('%s', %s);
+        var idx = 0;
+        if (params.name == params.value[0]) {
+            idx = 1;
+        }
         return params.value[0] + '<br>' +
                params.marker + ' ' +
-               params.seriesName + ': ' + fmt.format(parseFloat(params.value[1]));
+               params.seriesName + ': ' + fmt.format(parseFloat(params.value[idx]));
     }", locale, jsonlite::toJSON(opts, auto_unbox = TRUE)))
 
   tip <- structure(tip, class = c("JS_EVAL", "item_formatter"))


### PR DESCRIPTION
- Use the method provided by @artemklevtsov to fix the problem.
- Because {echarts4r} is not using the `dataset` property, so it may need to do lots of refactoring for using the `dataset[i].source` way to flip coordinates.

Source: https://github.com/JohnCoene/echarts4r/issues/79#issuecomment-531538341

Co-Authored-By: Artem Klevtsov <603798+artemklevtsov@users.noreply.github.com>