### PR TITLE
use seq_along() instead of 1:length()

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -1709,7 +1709,7 @@ e_gauge.echarts4r <- function(e, value, name, rm_x = TRUE, rm_y = TRUE, ...) {
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(value)) {
+  for (i in seq_along(value)) {
     serie <- list(
       data = list(list(value = value[i], name = name[i]))
     )
@@ -2843,7 +2843,7 @@ e_lm <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth
 e_lm.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE, model_args = list(), ...) {
   form <- as.formula(formula)
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     e$x$data[[i]] <- e$x$data[[i]][stats::complete.cases(e$x$data[[i]]), ]
 
     model_args$formula <- form
@@ -2911,7 +2911,7 @@ e_lm.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "non
 e_lm.echarts4rProxy <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE, model_args = list(), ...) {
   form <- as.formula(formula)
 
-  for (i in 1:length(e$chart$x$data)) {
+  for (i in seq_along(e$chart$x$data)) {
     e$chart$x$data[[i]] <- e$chart$x$data[[i]][stats::complete.cases(e$chart$x$data[[i]]), ]
 
     model_args$formula <- form
@@ -2983,7 +2983,7 @@ e_glm <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smoot
 e_glm.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE, model_args = list(), ...) {
   form <- as.formula(formula)
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     e$x$data[[i]] <- e$x$data[[i]][stats::complete.cases(e$x$data[[i]]), ]
 
     model_args$formula <- form
@@ -3051,7 +3051,7 @@ e_glm.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "no
 e_glm.echarts4rProxy <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE, model_args = list(), ...) {
   form <- as.formula(formula)
 
-  for (i in 1:length(e$chart$x$data)) {
+  for (i in seq_along(e$chart$x$data)) {
     e$chart$x$data[[i]] <- e$chart$x$data[[i]][stats::complete.cases(e$chart$x$data[[i]]), ]
 
     model_args$formula <- form
@@ -3125,7 +3125,7 @@ e_loess <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smo
 #' @importFrom stats complete.cases
 e_loess.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE,
                               x_index = 0, y_index = 0, model_args = list(), ...) {
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     e$x$data[[i]] <- e$x$data[[i]][stats::complete.cases(e$x$data[[i]]), ]
 
     model_args$formula <- as.formula(formula)
@@ -3203,7 +3203,7 @@ e_loess.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "
 #' @importFrom stats complete.cases
 e_loess.echarts4rProxy <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE,
                                    x_index = 0, y_index = 0, model_args = list(), ...) {
-  for (i in 1:length(e$chart$x$data)) {
+  for (i in seq_along(e$chart$x$data)) {
     e$chart$x$data[[i]] <- e$chart$x$data[[i]][stats::complete.cases(e$chart$x$data[[i]]), ]
 
     model_args$formula <- as.formula(formula)

--- a/R/add_.R
+++ b/R/add_.R
@@ -10,7 +10,7 @@ e_bar_ <- function(e, serie, bind = NULL, name = NULL, legend = TRUE, y_index = 
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     .build_data2(e$x$data[[i]], e$x$mapping$x, serie) -> vector
 
     if (!is.null(bind)) {
@@ -102,7 +102,7 @@ e_line_ <- function(e, serie, bind = NULL, name = NULL, legend = TRUE, y_index =
     e$x$facets$current <- e$x$facets$current + 1
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     .build_data2(e$x$data[[i]], e$x$mapping$x, serie) -> vector
@@ -194,7 +194,7 @@ e_area_ <- function(e, serie, bind = NULL, name = NULL, legend = TRUE, y_index =
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     .build_data2(e$x$data[[i]], e$x$mapping$x, serie) -> vector
@@ -286,7 +286,7 @@ e_step_ <- function(e, serie, bind = NULL, step = c("start", "middle", "end"), f
     stop("wrong step", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     .build_data2(e$x$data[[i]], e$x$mapping$x, serie) -> vector
@@ -384,7 +384,7 @@ e_scatter_ <- function(e, serie, size = NULL, bind = NULL, symbol = NULL, symbol
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     if (y_index != 0) {
       e <- .set_y_axis(e, serie, y_index, i)
     }
@@ -504,7 +504,7 @@ e_effect_scatter_ <- function(e, serie, size = NULL, bind = NULL, symbol = NULL,
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     if (y_index != 0) {
       e <- .set_y_axis(e, serie, y_index, i)
     }
@@ -614,7 +614,7 @@ e_candle_ <- function(e, opening, closing, low, high, bind = NULL, name = NULL, 
     stop("missing inputs", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     data <- .build_data2(e$x$data[[i]], opening, closing, low, high)
 
     if (!is.null(bind)) {
@@ -726,7 +726,7 @@ e_funnel_ <- function(e, values, labels, name = NULL, legend = TRUE, rm_x = TRUE
     stop("missing values or labels", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     funnel <- .build_data2(e$x$data[[i]], values)
@@ -812,7 +812,7 @@ e_heatmap_ <- function(e, y, z = NULL, bind = NULL, name = NULL, coord_system = 
     stop("must pass y", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     if (!is.null(z)) {
       xyz <- .build_data2(e$x$data[[i]], e$x$mapping$x, y, z)
     } else {
@@ -947,7 +947,7 @@ e_pie_ <- function(e, serie, name = NULL, legend = TRUE, rm_x = TRUE, rm_y = TRU
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     data <- .build_data2(e$x$data[[i]], serie)
@@ -1053,7 +1053,7 @@ e_river_ <- function(e, serie, name = NULL, legend = TRUE, rm_x = TRUE, rm_y = T
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     nm <- .name_it(e, serie, name, i)
 
     if (length(e$x$opts$xAxis$data)) {
@@ -1094,7 +1094,7 @@ e_boxplot_ <- function(e, serie, name = NULL, outliers = TRUE, ...) {
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     vector <- .build_boxplot(e, serie, i)
@@ -1199,7 +1199,7 @@ e_lines_3d_ <- function(e, source_lon, source_lat, target_lon, target_lat, sourc
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     data <- .map_lines(
       e,
       source_lon, source_lat,
@@ -1271,7 +1271,7 @@ e_line_3d_ <- function(e, y, z, name = NULL, coord_system = NULL, rm_x = TRUE, r
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # build JSON data
     data <- .build_data2(e$x$data[[i]], e$x$mapping$x, y, z)
@@ -1372,7 +1372,7 @@ e_bar_3d_ <- function(e, y, z, bind = NULL, coord_system = "cartesian3D", name =
   e <- .set_axis_3D(e, "y", y, 0)
   e <- .set_axis_3D(e, "z", z, 0)
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     if (coord_system != "cartesian3D") {
       data <- .build_data2(e$x$data[[i]], e$x$mapping$x, y, z)
 
@@ -1492,7 +1492,7 @@ e_surface_ <- function(e, y, z, bind = NULL, name = NULL, rm_x = TRUE, rm_y = TR
     e$x$opts$grid3D <- list(show = TRUE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     row.names(e$x$data[[i]]) <- NULL
 
     data <- e$x$data[[i]] %>%
@@ -1544,7 +1544,7 @@ e_lines_ <- function(e, source_lon, source_lat, target_lon, target_lat, source_n
   e <- .rm_axis(e, rm_y, "y")
 
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     data <- .map_lines(e, source_lon, source_lat, target_lon, target_lat, source_name, target_name, value, i)
 
     e.serie <- list(data = data)
@@ -1589,7 +1589,7 @@ e_scatter_3d_ <- function(e, y, z, color = NULL, size = NULL, bind = NULL, coord
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # globe
     if (coord_system != "cartesian3D") {
@@ -1749,7 +1749,7 @@ e_scatter_gl_ <- function(e, y, z, name = NULL, coord_system = "geo", rm_x = TRU
     stop("must pass y and z", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # remove axis
     e <- .rm_axis(e, rm_x, "x")
@@ -1839,7 +1839,7 @@ e_pictorial_ <- function(e, serie, symbol, bind = NULL, name = NULL, legend = TR
     e <- .set_x_axis(e, x_index)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     if (is.null(name)) { # defaults to column name
       name <- serie
     }
@@ -1906,7 +1906,7 @@ e_histogram_ <- function(e, serie, breaks = "Sturges", name = NULL, legend = TRU
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     data <- .get_data(e, serie, i)
     histogram <- hist(data, plot = FALSE, breaks)
 
@@ -1993,7 +1993,7 @@ e_density_ <- function(e, serie, breaks = "Sturges", name = NULL, legend = TRUE,
     stop("must pass serie", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     data <- .get_data(e, serie, i = i)
     histogram <- hist(data, plot = FALSE, breaks)
 
@@ -2101,7 +2101,7 @@ e_band_ <- function(e, min, max, stack = "confidence-band", symbol = c("none", "
   min_opts <- purrr::map(args, spl, 1)
   max_opts <- purrr::map(args, spl, 2)
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
 
     # min
     min_opts_index <- min_opts
@@ -2141,7 +2141,7 @@ e_band2_ <- function(e, lower, upper, name=NULL, legend=TRUE,
    
    args <- list(...)
    
-   for (i in 1:length(e$x$data)) {
+   for (i in seq_along(e$x$data)) {
      vector <- .build_data2(e$x$data[[i]], e$x$mapping$x, 
                                         lower, upper)
      e_serie <- list(data = vector)
@@ -2240,7 +2240,7 @@ e_error_bar_ <-  function (e, lower, upper,
                  ,jsonlite::toJSON(info),"'); ", renderer)
   renderJS <- htmlwidgets::JS(info)
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     vector <- .build_data2(e$x$data[[i]], e$x$mapping$x, 
                                        lower, upper)
     e_serie <- list(data = vector)

--- a/R/grid.R
+++ b/R/grid.R
@@ -112,7 +112,7 @@ e_axis_ <- function(e, serie = NULL, axis = c("x", "y", "z"), index = 0, formatt
   }
 
   if (dp >= 2) {
-    for (i in 1:length(attrs)) {
+    for (i in seq_along(attrs)) {
       arg <- names(attrs)[i]
       if (!e$x$tl) {
         e$x$opts[[axis]][[r.index]][[arg]] <- attrs[[i]]
@@ -121,7 +121,7 @@ e_axis_ <- function(e, serie = NULL, axis = c("x", "y", "z"), index = 0, formatt
       }
     }
   } else {
-    for (i in 1:length(attrs)) {
+    for (i in seq_along(attrs)) {
       arg <- names(attrs)[i]
       if (!e$x$tl) {
         e$x$opts[[axis]][[arg]] <- attrs[[i]]
@@ -502,7 +502,7 @@ e_radar_opts <- function(e, index = 0, ...) {
     }
   }
 
-  for (i in 1:length(attrs)) {
+  for (i in seq_along(attrs)) {
     arg <- names(attrs)[i]
     if (!e$x$tl) {
       e$x$opts$radar[[r.index]][[arg]] <- attrs[[i]]
@@ -572,7 +572,7 @@ e_single_axis <- function(e, index = 0, ...) {
 
     if (type == "category" || type == "time") {
       vect <- c()
-      for (i in 1:length(e$x$data)) {
+      for (i in seq_along(e$x$data)) {
         dat <- e$x$data[[i]] %>%
           dplyr::select(e$x$mapping$x) %>%
           unlist()

--- a/R/grid3d.R
+++ b/R/grid3d.R
@@ -57,7 +57,7 @@ e_axis_3d <- function(e, axis = c("x", "y", "z"), index = 0, ...) {
     stop("no attribute", call. = FALSE)
   }
 
-  for (i in 1:length(attrs)) {
+  for (i in seq_along(attrs)) {
     arg <- names(attrs)[i]
 
     if (!e$x$tl) {
@@ -159,7 +159,7 @@ e_grid_3d <- function(e, index = 0, ...) {
     stop("no attribute", call. = FALSE)
   }
 
-  for (i in 1:length(attrs)) {
+  for (i in seq_along(attrs)) {
     arg <- names(attrs)[i]
 
     if (!e$x$tl) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -214,11 +214,11 @@ e_labels <- function(e, show = TRUE, position = "top", ...) {
   )
 
   if (!e$x$tl) {
-    for (i in 1:length(e$x$opts$series)) {
+    for (i in seq_along(e$x$opts$series)) {
       e$x$opts$series[[i]]$label <- opts
     }
   } else {
-    for (i in 1:length(e$x$opts$baseOption$series)) {
+    for (i in seq_along(e$x$opts$baseOption$series)) {
       e$x$opts$baseOption$series[[i]]$label <- opts
     }
   }

--- a/R/map.R
+++ b/R/map.R
@@ -117,7 +117,7 @@ e_map_ <- function(e, serie = NULL, map = "world", name = NULL, rm_x = TRUE, rm_
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     app <- list(
       type = "map",
       map = map,
@@ -193,7 +193,7 @@ e_map_3d_ <- function(e, serie = NULL, map = "world", name = NULL, coord_system 
   e <- .rm_axis(e, rm_x, "x")
   e <- .rm_axis(e, rm_y, "y")
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     if (!is.null(serie)) {
       data <- .build_data2(e$x$data[[i]], serie)
       data <- .add_bind2(e, data, e$x$mapping$x, i = i)

--- a/R/mark.R
+++ b/R/mark.R
@@ -76,7 +76,7 @@ e_mark_point <- function(e, serie = NULL, data = NULL, ..., title = NULL, title_
   }
 
   if (is.null(serie)) {
-    index <- 1:length(if (e$x$tl) e$x$opts$options else e$x$opts$series)
+    index <- seq_along(if (e$x$tl) e$x$opts$options else e$x$opts$series)
   } else {
     index <- .get_index(e, serie)
   }
@@ -119,7 +119,7 @@ e_mark_line <- function(e, serie = NULL, data = NULL, ..., title = NULL, title_p
   }
 
   if (is.null(serie)) {
-    index <- 1:length(if (e$x$tl) e$x$opts$options else e$x$opts$series)
+    index <- seq_along(if (e$x$tl) e$x$opts$options else e$x$opts$series)
   } else {
     index <- .get_index(e, serie)
   }
@@ -162,7 +162,7 @@ e_mark_area <- function(e, serie = NULL, data = NULL, ..., title = NULL, title_p
   }
 
   if (is.null(serie)) {
-    index <- 1:length(if (e$x$tl) e$x$opts$options else e$x$opts$series)
+    index <- seq_along(if (e$x$tl) e$x$opts$options else e$x$opts$series)
   } else {
     index <- .get_index(e, serie)
   }

--- a/R/nesting.R
+++ b/R/nesting.R
@@ -58,13 +58,13 @@ e_add <- function(e, param, ...) {
     stop("missing e or what", call. = FALSE)
   }
 
-  for (i in 1:length(e$x$data)) {
+  for (i in seq_along(e$x$data)) {
     data <- e$x$data[[i]] %>%
       dplyr::select(...)
 
     data <- apply(data, 1, as.list)
 
-    for (j in 1:length(data)) {
+    for (j in seq_along(data)) {
       if (!e$x$tl) {
         e$x$opts$series[[i]]$data[[j]][[param]] <- data[[j]]
       } else {

--- a/R/opts.R
+++ b/R/opts.R
@@ -367,7 +367,7 @@ e_legend <- function(e, show = TRUE, type = c("plain", "scroll"), icons = NULL, 
       )
     }
 
-    for (i in 1:length(e$x$opts$legend$data)) {
+    for (i in seq_along(e$x$opts$legend$data)) {
       e$x$opts$legend$data[[i]] <- list(name = e$x$opts$legend$data[[i]])
       e$x$opts$legend$data[[i]]$icon <- icons[[i]]
     }
@@ -441,12 +441,12 @@ e_toolbox_feature <- function(e, feature, ...) {
       e$x$opts$toolbox <- list(feature = list())
     }
 
-    for (i in 1:length(feature)) {
+    for (i in seq_along(feature)) {
       e$x$opts$toolbox$feature[[feature[i]]] <- list()
     }
 
     if (length(options)) {
-      for (i in 1:length(options)) {
+      for (i in seq_along(options)) {
         e$x$opts$toolbox$feature[[feature]][[names(options)[i]]] <- options[[i]]
       }
     }
@@ -455,12 +455,12 @@ e_toolbox_feature <- function(e, feature, ...) {
       e$x$opts$baseOption$toolbox <- list(feature = list())
     }
 
-    for (i in 1:length(feature)) {
+    for (i in seq_along(feature)) {
       e$x$opts$baseOption$toolbox$feature[[feature[i]]] <- list()
     }
 
     if (length(options)) {
-      for (i in 1:length(options)) {
+      for (i in seq_along(options)) {
         e$x$opts$baseOption$toolbox$feature[[feature]][[names(options)[i]]] <- options[[i]]
       }
     }
@@ -815,7 +815,7 @@ e_flip_coords <- function(e) {
 
     names(e$x$opts) <- n
 
-    for (i in 1:length(e$x$opts$series)) {
+    for (i in seq_along(e$x$opts$series)) {
       for (j in 1:length(e$x$opts$series[[i]]$data)) {
         vals <- e$x$opts$series[[i]]$data[[j]]$value
         e$x$opts$series[[i]]$data[[j]]$value <- rev(vals)


### PR DESCRIPTION
I think `seq_along()` is better than `1:length()` as the latter will cause unexpected results when `x` is length zero. In addition, it's faster.

``` r
x <- character()
1:length(x)
#> [1] 1 0
seq_along(x)
#> integer(0)
```

<sup>Created on 2020-11-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
