### PR TITLE
e_band() now displays correct upper lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,9 @@ Version: 0.3.4
 Authors@R: c(
   person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre", "cph")), 
   person(given = "Wei", family = "Su", email = "swsoyee@gmail.com", role = "ctb"),
-  person("Helgasoft", ".com", email="contact@helgasoft.com", role = "ctb"))
+  person("Helgasoft", ".com", email="contact@helgasoft.com", role = "ctb"),
+  person("Xianying", "Tan", email = "shrektan@126.com", role = "ctb", comment = c(ORCID = "0000-0002-6072-3521"))
+  )
 Description: Easily create interactive charts by leveraging the 'Echarts Javascript' library which includes
     36 chart types, themes, 'Shiny' proxies and animations.
 License: Apache License (>= 2.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Fixed `e_parallel` arguments, see [#223](https://github.com/JohnCoene/echarts4r/issues/223)
 - Accept `data.tree` data for easy creation of tree, treemaps and sunbursts, see [#207](https://github.com/JohnCoene/echarts4r/issues/207)
 - Fix ordering in timeline [#234](https://github.com/JohnCoene/echarts4r/issues/234)
+- Fix the issue that `e_band()` displays the upper band incorrectly, see [#237](https://github.com/JohnCoene/echarts4r/issues/237). Thanks @shrektan for the reporting and PR.
 
 # echarts4r 0.3.3
 

--- a/R/add_.R
+++ b/R/add_.R
@@ -2113,7 +2113,7 @@ e_band_ <- function(e, min, max, stack = "confidence-band", symbol = c("none", "
     e <- do.call(e_line_, min_opts_index)
 
     # max
-    # e$x$data[[i]][, max] <- e$x$data[[i]][[serie]] - e$x$data[[i]][[max]]
+    e$x$data[[i]][, max] <- e$x$data[[i]][, max] - e$x$data[[i]][, min]
     max_opts_index <- max_opts
     max_opts_index$e <- e
     max_opts_index$stack <- stack


### PR DESCRIPTION
Closes #237



## Code

```r
library(echarts4r)
df <- data.frame(
  x = 1:10,
  y = runif(10, 5, 10)
) %>%
  dplyr::mutate(
    lwr = y - 2,
    upr = y + 2
  )

df %>%
  e_charts(x) %>%
  e_line(y) %>%
  e_band(lwr, upr)
```


## Before the PR

![image](https://user-images.githubusercontent.com/8368933/99957675-0c1c8380-2dc3-11eb-9447-8e77d5e8427c.png)


## After the PR

![image](https://user-images.githubusercontent.com/8368933/99958102-b72d3d00-2dc3-11eb-9793-b28693cecb75.png)
