### PR TITLE
fix e_add (proxy) not working with e_radar, e_sunburst, e_treemap and e_boxplot

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -918,7 +918,7 @@ e_radar.echarts4rProxy <- function(
 
   serie <- deparse(substitute(serie))
 
-  e$chart <- e_radar_(e, serie, max, name, legend, rm_x, rm_y, ..., radar = radar)
+  e$chart <- e_radar_(e$chart, serie, max, name, legend, rm_x, rm_y, ..., radar = radar)
   return(e)
 }
 
@@ -1794,7 +1794,7 @@ e_sunburst.echarts4r <- function(e, styles = NULL, names = NULL, levels = NULL, 
 #' @export
 #' @method e_sunburst echarts4rProxy
 e_sunburst.echarts4rProxy <- function(e, styles = NULL, names = NULL, levels = NULL, rm_x = TRUE, rm_y = TRUE, ...) {
-  e$chart <- e_sunburst_(e, styles, names, levels, rm_x, rm_y, ...)
+  e$chart <- e_sunburst_(e$chart, styles, names, levels, rm_x, rm_y, ...)
 
   return(e)
 }
@@ -1859,7 +1859,7 @@ e_treemap.echarts4r <- function(e, styles = NULL, names = NULL, levels = NULL, r
 #' @export
 #' @method e_treemap echarts4rProxy
 e_treemap.echarts4rProxy <- function(e, styles = NULL, names = NULL, levels = NULL, rm_x = TRUE, rm_y = TRUE, ...) {
-  e$chart <- e_treemap_(e, styles, names, levels, rm_x, rm_y, ...)
+  e$chart <- e_treemap_(e$chart, styles, names, levels, rm_x, rm_y, ...)
 
   return(e)
 }
@@ -1962,7 +1962,7 @@ e_boxplot.echarts4rProxy <- function(e, serie, name = NULL, outliers = TRUE, ...
     name <- deparse(substitute(serie))
   }
 
-  e$chart <- e_boxplot_(e, deparse(substitute(serie)), name, outliers, ...)
+  e$chart <- e_boxplot_(e$chart, deparse(substitute(serie)), name, outliers, ...)
   return(e)
 }
 


### PR DESCRIPTION
Related to #276, #291 and #209.
For the 4 mentionned layers (radar, sunburst, treemap and boxplot), the code for adding a new serie via a proxy was not updated (and is different than all the other layers), thus blocking when trying to test `e$x$tl` while it should in fact test `e$chart$x$tl`.

Here's a minimal app that reproduce the problem :
```
library(shiny)
library(tidyverse)
library(echarts4r)

radar_df <- tibble(ValX = c("A", "B", "C"), ValY = 1:3)
tree_df <- tibble(parents = c("A", "B", "C"), labels = c("x", "y", "z"), value = 1:3)
boxplot_df <- tibble(ValX = sample(LETTERS[1:3], size = 10, replace = TRUE), ValY = rnorm(10))
ui <- fluidPage(
  column(2,
         fluidRow(actionButton("addserie_radar", label = "Add radar")),
         fluidRow(actionButton("addserie_sunburst", label = "Add sunburst")),
         fluidRow(actionButton("addserie_treemap", label = "Add treemap")),
         fluidRow(actionButton("addserie_boxplot", label = "Add boxplot"))
         ),
  column(2, echarts4rOutput("radar")),
  column(2, echarts4rOutput("sunburst")),
  column(2, echarts4rOutput("treemap")),
  column(2, echarts4rOutput("boxplot"))
)

server <- function(input, output) {
  output$radar <- renderEcharts4r({
    e_charts(data = base_df, ValX) %>%
      e_radar(serie = ValY, name = "Base", max = 5)
  })
  
  output$sunburst <- renderEcharts4r({
    e_charts(sunburst_df) %>%
      e_sunburst()
  })
  
  output$treemap <- renderEcharts4r({
    e_charts(sunburst_df) %>%
      e_treemap(names = "Base")
  })
  
  output$boxplot <- renderEcharts4r({
    boxplot_df %>%
      group_by(ValX) %>%
      e_charts() %>%
      e_boxplot(ValY, name = "Base")
  })
  
  
  observeEvent(input$addserie_radar,{
    serie_name <- sample(LETTERS, size = 5) %>% paste0(collapse = "")
    radar_serie <- radar_df %>% mutate(ValY = runif(n = 3, min = 0, max = 5))
    echarts4rProxy("radar", data = radar_serie, x = ValX) %>%
      e_radar(serie = ValY, name = serie_name) %>%
      e_execute()
  })
  
  observeEvent(input$addserie_sunburst,{
    serie_name <- sample(LETTERS, size = 5) %>% paste0(collapse = "")
    tree_serie <- tibble(parents = c("A", "B", "C"), labels = sample(letters, size = 3, replace = FALSE), value = runif(n = 3, min = 1, max = 5))
    echarts4r_proxy("sunburst", data = tree_serie) %>%
      e_sunburst(names = serie_name) %>%
      e_execute()
  })
  
  observeEvent(input$addserie_treemap,{
    serie_name <- sample(LETTERS, size = 5) %>% paste0(collapse = "")
    tree_serie <- tree_df %>% mutate(value = runif(min = 0, max = 5, n = 3))
    echarts4r_proxy("treemap", data = tree_serie) %>%
      e_treemap(names = serie_name) %>%
      e_execute()
  })
  
  observeEvent(input$addserie_boxplot,{
    serie_name <- sample(LETTERS, size = 5) %>% paste0(collapse = "")
    boxplot_serie <- boxplot_df %>% mutate(ValY = rnorm(10))
    echarts4r_proxy("boxplot", data = boxplot_serie %>% group_by(ValX)) %>%
      e_boxplot(ValY, names = serie_name) %>%
      e_execute()
  })
}

shinyApp(ui = ui, server = server)
```
Run before the fix (echarts4r v4.0.0) :
![fail](https://user-images.githubusercontent.com/807703/113156590-6d090c00-923a-11eb-8977-5acaf9b24e9b.gif)

Run after the fix :
![success](https://user-images.githubusercontent.com/807703/113156210-126fb000-923a-11eb-9b62-4c7d694cd225.gif)


