### PR TITLE
fix e_remove_serie_p when using serie_index

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Authors@R: c(
   person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre", "cph")), 
   person(given = "Wei", family = "Su", email = "swsoyee@gmail.com", role = "ctb"),
   person(family = "Helgasoft", email="contact@helgasoft.com", role = "ctb"),
-  person("Xianying", "Tan", email = "shrektan@126.com", role = "ctb", comment = c(ORCID = "0000-0002-6072-3521"))
+  person("Xianying", "Tan", email = "shrektan@126.com", role = "ctb", comment = c(ORCID = "0000-0002-6072-3521")),
+  person("Robin", "Cura", email = "robin.cura@gmail.com", role = "ctb", comment = c(ORCID = "0000-0001-5926-1828"))
   )
 Description: Easily create interactive charts by leveraging the 'Echarts Javascript' library which includes
     36 chart types, themes, 'Shiny' proxies and animations.

--- a/inst/htmlwidgets/echarts4r.js
+++ b/inst/htmlwidgets/echarts4r.js
@@ -238,6 +238,10 @@ function distinct(value, index, self) {
   return self.indexOf(value) === index;
 }
 
+function rm_undefined(el){
+  return el != undefined;
+}
+
 if (HTMLWidgets.shinyMode) {
   
   // DRAW
@@ -376,12 +380,12 @@ if (HTMLWidgets.shinyMode) {
         if(opts.legend.length > 0)
           if(data.opts.legend.data)
             opts.legend[0].data = opts.legend[0].data.concat(data.opts.legend.data);
-
+        
         // x Axis
         if(opts.xAxis){
           if(opts.xAxis[0].data){
             let xaxis = opts.xAxis[0].data.concat(data.opts.xAxis[0].data);
-            xaxis = xaxis.filter(distinct);
+            xaxis = xaxis.filter(distinct).filter(rm_undefined);
             opts.xAxis[0].data = xaxis;
           }
         }
@@ -390,7 +394,7 @@ if (HTMLWidgets.shinyMode) {
         if(opts.yAxis){
           if(opts.yAxis[0].data){
             let yaxis = opts.yAxis[0].data.concat(data.opts.yAxis[0].data);
-            yaxis = yaxis.filter(distinct);
+            yaxis = yaxis.filter(distinct).filter(rm_undefined);
             opts.yAxis[0].data = yaxis;
           }
         }

--- a/inst/htmlwidgets/echarts4r.js
+++ b/inst/htmlwidgets/echarts4r.js
@@ -401,6 +401,7 @@ if (HTMLWidgets.shinyMode) {
 
   Shiny.addCustomMessageHandler('e_remove_serie_p',
     function(data) {
+      
       var chart = get_e_charts(data.id);
       if (typeof chart != 'undefined') {
         let opts = chart.getOption();
@@ -415,8 +416,9 @@ if (HTMLWidgets.shinyMode) {
           opts.series = series;
         }
 
-        if(data.serie_index)
-          opts.series = opts.series.splice(data.index, 1);
+        if(data.serie_index != null){
+          opts.series = opts.series.splice(data.serie_index, 1);
+        }
 
         chart.setOption(opts, true);
       }

--- a/inst/htmlwidgets/echarts4r.js
+++ b/inst/htmlwidgets/echarts4r.js
@@ -409,8 +409,14 @@ if (HTMLWidgets.shinyMode) {
         if(data.serie_name){
           let series = opts.series;
           series.forEach(function(s, index){
+            if (typeof s.name == "undefined"){
+             if (s.data[[0]].name == data.serie_name){
+               this.splice(index, 1);
+             }
+            } else {
             if(s.name == data.serie_name){
               this.splice(index, 1);
+            }
             }
           }, series)
           opts.series = series;


### PR DESCRIPTION
- data.index was a typo, should be data.serie_index
- checking for true (vs != null) misworks when serie_index = 0 (ie. first serie)

This fixes the problem with e_remove_serie that's discussed in #300 .
The only way atm to remove a radar serie is through the index, as the serie name does'nt work : with radar plots (and other array-based series structures), there is no `opts.series[[i]].name`, as the series are arrays and their name are inside `opts.series[[i]].data[[0]].name`.