### PR TITLE
Fixed parenthesis for tree graph

### DIFF
--- a/vignettes/chart_types.Rmd
+++ b/vignettes/chart_types.Rmd
@@ -248,9 +248,9 @@ tree <- tibble(
          tibble(name = c("forest", "river")),   # 3rd level 
          tibble(name = c("fish", "kelp"),
             children = list(
-               tibble(name = c("shark", "tuna"),  # 4th level 
+               tibble(name = c("shark", "tuna")),  # 4th level 
                NULL  # kelp
-            ))
+            )
          )
        ))
   )


### PR DESCRIPTION
Earlier, shark and tuna showed as sub category for both fish and kelp. Now they only show for fish.