### PR TITLE
Fix `e_legend` such that `icon` argument can be used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .Rproj.user
 .Rhistory
 .RData
-echarts4.Rproj
+*.Rproj
 usa.json
 inst/doc
 *.vs/

--- a/R/opts.R
+++ b/R/opts.R
@@ -381,7 +381,10 @@ e_legend <- function(e, show = TRUE, type = c("plain", "scroll"), icons = NULL, 
   }
 
   if (!is.null(icons)) {
-    if (length(icons) < length(e$x$opts$legend$data)) {
+    if (length(icons) == 1) {
+      e$x$opts$legend$icon <- icons
+      icons <- NULL
+    } else if (length(icons) < length(e$x$opts$legend$data)) {
       stop(
         "invalid number of icons; ",
         length(icons),
@@ -391,6 +394,7 @@ e_legend <- function(e, show = TRUE, type = c("plain", "scroll"), icons = NULL, 
       )
     }
 
+    
     for (i in seq_along(e$x$opts$legend$data)) {
       e$x$opts$legend$data[[i]] <- list(name = e$x$opts$legend$data[[i]])
       e$x$opts$legend$data[[i]]$icon <- icons[[i]]


### PR DESCRIPTION
R's partial matching of arguments made it such that a single value passed as argument `icon` to `e_legend` when multiple `legend$data` objects are present in the chart causes this error:

```
Error in echarts4r::e_legend(e, icon = "circle") : 
  invalid number of icons; 1 icons passed but 4 legend items.
```

This modifies `e_legend` to allow for the expected behavior which uses it as the `icon` argument in `opts$legend` effectively changing the icon for the entire legend.