### PR TITLE
Expand e_area() documentation

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -168,7 +168,9 @@ e_line.echarts4rProxy <- function(
 
 #' Area
 #'
-#' Add area serie.
+#' Add area serie. Note that this is NOT an unique series type. Rather, this
+#' function is a shorthand for using `e_bar()` with `areaStyle = list()`
+#' enabled.
 #'
 #' @inheritParams e_bar
 #'


### PR DESCRIPTION
This PR updates the `e_area()` documentation. It elaborates that there is no such thing as a type=area chart in eCharts, which explains why the documentation links to type=line charts. It is specified that using this function is a shorthand for using `e_bar()` with `areaStyle = list()`.