### PR TITLE
Documentation: implementing a static grid for small charts

### DIFF
--- a/R/echarts4r.R
+++ b/R/echarts4r.R
@@ -27,7 +27,7 @@ echarts_build <- function(e) {
 #' @param renderer Renderer, takes \code{canvas} (default) or \code{svg}.
 #' @param timeline Set to \code{TRUE} to build a timeline, see timeline section.
 #' @param ... Any other argument.
-#' @param reorder Set the \code{FALSE} to not reorder numeric x axis values.
+#' @param reorder Set to \code{FALSE} to not reorder numeric x axis values.
 #'
 #' @section Timeline:
 #' The timeline feature currently supports the following chart types.

--- a/R/echarts4r.R
+++ b/R/echarts4r.R
@@ -472,6 +472,15 @@ e_data <- function(e, data, x) {
 #' @param id Target chart id.
 #' @param session Shiny session.
 #'
+#' @section Details: The chart is created inside a parent *<div>* element, the
+#'   dimensions of which are controlled by the \code{'width'} and
+#'   \code{'height'} arguments. When these dimensions are small, it is possible
+#'   that the chart \code{'grid'} resizes to a size larger than the parent,
+#'   which might result in unexpected size given the input arguments. To disable
+#'   this automatic readjustment, define a static \code{\link{e_grid}} like the
+#'   following: \code{'e_grid(e = current_chart, top = 0, left = 20, right = 0,
+#'   bottom = 20)'}.
+#'   
 #' @section Callbacks:
 #' \itemize{
 #'   \item{\code{id_brush}: returns data on brushed data points.}

--- a/R/echarts4r.R
+++ b/R/echarts4r.R
@@ -29,8 +29,17 @@ echarts_build <- function(e) {
 #' @param ... Any other argument.
 #' @param reorder Set to \code{FALSE} to not reorder numeric x axis values.
 #'
-#' @section Timeline:
-#' The timeline feature currently supports the following chart types.
+#' @section Details: The chart is created inside a parent *<div>* element, the
+#'   dimensions of which are controlled by the \code{'width'} and
+#'   \code{'height'} arguments. When these dimensions are small, it is possible
+#'   that the chart \code{'grid'} resizes to a size larger than the parent,
+#'   which might result in unexpected size given the input arguments. To disable
+#'   this automatic readjustment, define a static \code{\link{e_grid}} like the
+#'   following: \code{'e_grid(e = current_chart, top = 0, left = 20, right = 0,
+#'   bottom = 20)'}.
+#'
+#' @section Timeline: The timeline feature currently supports the following
+#'   chart types.
 #' \itemize{
 #'   \item{\code{\link{e_bar}}}
 #'   \item{\code{\link{e_line}}}

--- a/R/echarts4r.R
+++ b/R/echarts4r.R
@@ -29,8 +29,8 @@ echarts_build <- function(e) {
 #' @param ... Any other argument.
 #' @param reorder Set to \code{FALSE} to not reorder numeric x axis values.
 #'
-#' @section Details: The chart is created inside a parent *<div>* element, the
-#'   dimensions of which are controlled by the \code{'width'} and
+#' @section Details: The chart is created inside a parent \code{'<div>'}
+#'   element, the dimensions of which are controlled by the \code{'width'} and
 #'   \code{'height'} arguments. When these dimensions are small, it is possible
 #'   that the chart \code{'grid'} resizes to a size larger than the parent,
 #'   which might result in unexpected size given the input arguments. To disable
@@ -472,8 +472,8 @@ e_data <- function(e, data, x) {
 #' @param id Target chart id.
 #' @param session Shiny session.
 #'
-#' @section Details: The chart is created inside a parent *<div>* element, the
-#'   dimensions of which are controlled by the \code{'width'} and
+#' @section Details: The chart is created inside a parent \code{'<div>'}
+#'   element, the dimensions of which are controlled by the \code{'width'} and
 #'   \code{'height'} arguments. When these dimensions are small, it is possible
 #'   that the chart \code{'grid'} resizes to a size larger than the parent,
 #'   which might result in unexpected size given the input arguments. To disable


### PR DESCRIPTION
As a followup to this issue: https://github.com/JohnCoene/echarts4r/issues/558
A solution for creating small eCharts objects (e.g. height of sub 100px) was described, which involves setting a static grid so the resulting chart doesn't outgrow it's parent div.
This PR adds this explanation to the documentation of the `e_charts`, `echarts4rOutput`, `renderEcharts4r`... functions.

Also fixed a typo in the e_charts() *reorder* argument documentation.

Note: I'm not sure if the man/.Rd files need to be included in the PR, or if they are built automatically during CI/CD. If they're needed, I'll add them :)