### PR TITLE
feat: logic to split grouped tidytable

### DIFF
--- a/R/group2series.R
+++ b/R/group2series.R
@@ -8,6 +8,12 @@ map_grps_ <- function(data, timeline = FALSE) {
     splat <- purrr::map(splat, as.data.frame)
     names(splat) <- keys
     data <- splat
+  } else if (inherits(data, "grouped_tt")) {
+    splat <- split(data, factor(data[[attr(data, "groups")]]))
+    keys <- names(splat)
+    splat <- purrr::map(splat, as.data.frame)
+    names(splat) <- keys
+    data <- splat
   } else {
     if (inherits(data, "data.frame")) {
       data <- as.data.frame(data)


### PR DESCRIPTION
This PR adds minimal code to support stacked bar chart with a `grouped_tt` class (grouped `tidytable`).

Currently, `echarts4r` handles grouped tibbles nicely (class `grouped_df`). The code below will make a stacked barplot..

```
x <- c("a", "a", "b", "b")
g <- c("g1", "g2", "g1", "g2")
y <- c(1, 1, 1, 1)

d <- data.frame(x, g, y)
grp_d <- d |> dplyr::group_by(g)

grp_d |>
    e_chart(x) |>
    e_bar(y, stack = "g")
```
![image](https://github.com/JohnCoene/echarts4r/assets/2613403/a65e6bb1-4a13-479a-8007-2a84576b0a4a)

However, if one does not user `dplyr` but `tidytable`, the resulting grouped data frame is not of class `grouped_df`, but `grouped_tt`.  The code results with this 

```
x <- c("a", "a", "b", "b")
g <- c("g1", "g2", "g1", "g2")
y <- c(1, 1, 1, 1)

d <- data.frame(x, g, y)
grp_d <- d |> tidytable::group_by(g)

grp_d |>
    e_chart(x) |>
    e_bar(y, stack = "g")
```

![image](https://github.com/JohnCoene/echarts4r/assets/2613403/3d3d7e87-d5ce-4511-8cc5-94206c2583c9)

With the this PR, I added an `else if` condition in `map_grps_` to use `base::split` to split the grouped tidytable (instead of `dplyr::group_split`), such that grouped tidytables also produce stacked barcharts.

I have not tested it thoroughly. I don't know all the features that depend on `map_grps_`, but the proposed addition should not affect any dplyr-dependent code. Happy to work on this more if needed. 

Thanks! 
 