### PR TITLE
feat: allow setting node XY coordinates when layout="none"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Authors@R: c(
   person("Robin", "Cura", email = "robin.cura@gmail.com", role = "ctb", comment = c(ORCID = "0000-0001-5926-1828")),
   person("Mathida", "Chuk", email = "mathidachuk@gmail.com", role = "ctb"),
   person("Robert", "Koetsier", email = "rk8roko@gmail.com ", role = "ctb", comment = c(ORCID = "0000-0002-4477-5401")),
-  person("Jelle", "Geertsma", email = "rdatasculptor@gmail.com", role = "ctb")
+  person("Jelle", "Geertsma", email = "rdatasculptor@gmail.com", role = "ctb"),
+  person("Teofil", "Nakov", email = "teofiln@gmail.com", role = "ctb")
   )
 Description: Easily create interactive charts by leveraging the 'Echarts Javascript' library which includes
     36 chart types, themes, 'Shiny' proxies and animations.

--- a/R/add.R
+++ b/R/add.R
@@ -11,9 +11,9 @@
 #' @param ... Any other option to pass, check See Also section.
 #' @param x_index,y_index Indexes of x and y axis.
 #' @param coord_system Coordinate system to plot against.
-#' 
+#'
 #' @note The bar serie expects the data on the x axis to be
-#' \code{categorical} in R this means a \code{factor} or 
+#' \code{categorical} in R this means a \code{factor} or
 #' \code{character}. If the data on the x axis is numeric
 #' everything should work well in most cases but strange
 #' behaviour may be observed.
@@ -22,7 +22,7 @@
 #' library(dplyr)
 #'
 #' mtcars |>
-#'   tibble::rownames_to_column("model") |> 
+#'   tibble::rownames_to_column("model") |>
 #'   mutate(total = mpg + qsec) |>
 #'   arrange(desc(total)) |>
 #'   e_charts(model) |>
@@ -96,32 +96,30 @@ e_bar.echarts4rProxy <- function(e, serie, bind, name = NULL, legend = TRUE, y_i
 #' @rdname e_line
 #' @export
 e_line <- function(
-  e,
-  serie,
-  bind,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   UseMethod("e_line")
 }
 
 #' @export
 #' @method e_line echarts4r
 e_line.echarts4r <- function(
-  e,
-  serie,
-  bind,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -140,16 +138,15 @@ e_line.echarts4r <- function(
 #' @export
 #' @method e_line echarts4rProxy
 e_line.echarts4rProxy <- function(
-  e,
-  serie,
-  bind,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -192,32 +189,30 @@ e_line.echarts4rProxy <- function(
 #' @rdname e_area
 #' @export
 e_area <- function(
-  e,
-  serie,
-  bind,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   UseMethod("e_area")
 }
 
 #' @export
 #' @method e_area echarts4r
 e_area.echarts4r <- function(
-  e,
-  serie,
-  bind,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -236,16 +231,15 @@ e_area.echarts4r <- function(
 #' @export
 #' @method e_area echarts4rProxy
 e_area.echarts4rProxy <- function(
-  e,
-  serie,
-  bind,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -272,7 +266,7 @@ e_area.echarts4rProxy <- function(
 #'
 #' @examples
 #' USArrests |>
-#'   tibble::rownames_to_column("State") |> 
+#'   tibble::rownames_to_column("State") |>
 #'   e_charts(State) |>
 #'   e_step(Murder, name = "Start", step = "start", fill = TRUE) |>
 #'   e_step(Rape, name = "Middle", step = "middle") |>
@@ -290,36 +284,34 @@ e_area.echarts4rProxy <- function(
 #' @rdname e_step
 #' @export
 e_step <- function(
-  e,
-  serie,
-  bind,
-  step = c("start", "middle", "end"),
-  fill = FALSE,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    step = c("start", "middle", "end"),
+    fill = FALSE,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   UseMethod("e_step")
 }
 
 #' @export
 #' @method e_step echarts4r
 e_step.echarts4r <- function(
-  e,
-  serie,
-  bind,
-  step = c("start", "middle", "end"),
-  fill = FALSE,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    step = c("start", "middle", "end"),
+    fill = FALSE,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -338,18 +330,17 @@ e_step.echarts4r <- function(
 #' @export
 #' @method e_step echarts4rProxy
 e_step.echarts4rProxy <- function(
-  e,
-  serie,
-  bind,
-  step = c("start", "middle", "end"),
-  fill = FALSE,
-  name = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    serie,
+    bind,
+    step = c("start", "middle", "end"),
+    fill = FALSE,
+    name = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -465,50 +456,48 @@ e_step.echarts4rProxy <- function(
 #' @rdname scatter
 #' @export
 e_scatter <- function(
-  e,
-  serie,
-  size,
-  bind,
-  symbol = NULL,
-  symbol_size = 1,
-  scale = e_scale,
-  scale_js = "function(data){ return data[3];}",
-  name = NULL,
-  coord_system = "cartesian2d",
-  jitter_factor = 0,
-  jitter_amount = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    serie,
+    size,
+    bind,
+    symbol = NULL,
+    symbol_size = 1,
+    scale = e_scale,
+    scale_js = "function(data){ return data[3];}",
+    name = NULL,
+    coord_system = "cartesian2d",
+    jitter_factor = 0,
+    jitter_amount = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   UseMethod("e_scatter")
 }
 
 #' @export
 #' @method e_scatter echarts4r
 e_scatter.echarts4r <- function(
-  e,
-  serie,
-  size,
-  bind,
-  symbol = NULL,
-  symbol_size = 1,
-  scale = e_scale,
-  scale_js = "function(data){ return data[3];}",
-  name = NULL,
-  coord_system = "cartesian2d",
-  jitter_factor = 0,
-  jitter_amount = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    serie,
+    size,
+    bind,
+    symbol = NULL,
+    symbol_size = 1,
+    scale = e_scale,
+    scale_js = "function(data){ return data[3];}",
+    name = NULL,
+    coord_system = "cartesian2d",
+    jitter_factor = 0,
+    jitter_amount = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -552,25 +541,24 @@ e_scatter.echarts4r <- function(
 #' @export
 #' @method e_scatter echarts4rProxy
 e_scatter.echarts4rProxy <- function(
-  e,
-  serie,
-  size,
-  bind,
-  symbol = NULL,
-  symbol_size = 1,
-  scale = e_scale,
-  scale_js = "function(data){ return data[3];}",
-  name = NULL,
-  coord_system = "cartesian2d",
-  jitter_factor = 0,
-  jitter_amount = NULL,
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    serie,
+    size,
+    bind,
+    symbol = NULL,
+    symbol_size = 1,
+    scale = e_scale,
+    scale_js = "function(data){ return data[3];}",
+    name = NULL,
+    coord_system = "cartesian2d",
+    jitter_factor = 0,
+    jitter_amount = NULL,
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -616,46 +604,44 @@ e_scatter.echarts4rProxy <- function(
 #' @rdname scatter
 #' @export
 e_effect_scatter <- function(
-  e,
-  serie,
-  size,
-  bind,
-  symbol = NULL,
-  symbol_size = 1,
-  scale = e_scale,
-  scale_js = "function(data){ return data[3];}",
-  name = NULL,
-  coord_system = "cartesian2d",
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    serie,
+    size,
+    bind,
+    symbol = NULL,
+    symbol_size = 1,
+    scale = e_scale,
+    scale_js = "function(data){ return data[3];}",
+    name = NULL,
+    coord_system = "cartesian2d",
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   UseMethod("e_effect_scatter")
 }
 
 #' @export
 #' @method e_effect_scatter echarts4r
 e_effect_scatter.echarts4r <- function(
-  e,
-  serie,
-  size,
-  bind,
-  symbol = NULL,
-  symbol_size = 1,
-  scale = e_scale,
-  scale_js = "function(data){ return data[3];}",
-  name = NULL,
-  coord_system = "cartesian2d",
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    serie,
+    size,
+    bind,
+    symbol = NULL,
+    symbol_size = 1,
+    scale = e_scale,
+    scale_js = "function(data){ return data[3];}",
+    name = NULL,
+    coord_system = "cartesian2d",
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -697,23 +683,22 @@ e_effect_scatter.echarts4r <- function(
 #' @export
 #' @method e_effect_scatter echarts4rProxy
 e_effect_scatter.echarts4rProxy <- function(
-  e,
-  serie,
-  size,
-  bind,
-  symbol = NULL,
-  symbol_size = 1,
-  scale = e_scale,
-  scale_js = "function(data){ return data[3];}",
-  name = NULL,
-  coord_system = "cartesian2d",
-  legend = TRUE,
-  y_index = 0,
-  x_index = 0,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    serie,
+    size,
+    bind,
+    symbol = NULL,
+    symbol_size = 1,
+    scale = e_scale,
+    scale_js = "function(data){ return data[3];}",
+    name = NULL,
+    coord_system = "cartesian2d",
+    legend = TRUE,
+    y_index = 0,
+    x_index = 0,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -870,32 +855,30 @@ e_candle.echarts4rProxy <- function(e, opening, closing, low, high, bind, name =
 #' @rdname e_radar
 #' @export
 e_radar <- function(
-  e,
-  serie,
-  max = 100,
-  name = NULL,
-  legend = TRUE,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...,
-  radar = list()
-) {
+    e,
+    serie,
+    max = 100,
+    name = NULL,
+    legend = TRUE,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...,
+    radar = list()) {
   UseMethod("e_radar")
 }
 
 #' @export
 #' @method e_radar echarts4r
 e_radar.echarts4r <- function(
-  e,
-  serie,
-  max = 100,
-  name = NULL,
-  legend = TRUE,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...,
-  radar = list()
-) {
+    e,
+    serie,
+    max = 100,
+    name = NULL,
+    legend = TRUE,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...,
+    radar = list()) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -908,16 +891,15 @@ e_radar.echarts4r <- function(
 #' @export
 #' @method e_radar echarts4rProxy
 e_radar.echarts4rProxy <- function(
-  e,
-  serie,
-  max = 100,
-  name = NULL,
-  legend = TRUE,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...,
-  radar = list()
-) {
+    e,
+    serie,
+    max = 100,
+    name = NULL,
+    legend = TRUE,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...,
+    radar = list()) {
   if (missing(serie)) {
     stop("must pass serie", call. = FALSE)
   }
@@ -1084,6 +1066,7 @@ e_sankey.echarts4rProxy <- function(e, source, target, value, layout = "none", r
 #' @param symbol Symbols of nodes.
 #' @param legend Whether to add serie to legend.
 #' @param category Group of nodes (i.e.: group membership).
+#' @param xpos,ypos X and Y coordinates for nodes. Valid when \code{layout = "none"}
 #' @param edges Data.frame of edges.
 #' @param source,target Column names of source and target.
 #' @param layout Layout, one of \code{force}, \code{none} or \code{circular}.
@@ -1109,7 +1092,7 @@ e_sankey.echarts4rProxy <- function(e, source, target, value, layout = "none", r
 #'   source = sample(nodes$name, 20, replace = TRUE),
 #'   target = sample(nodes$name, 20, replace = TRUE),
 #'   value = value_edges,
-#'   size = ceiling(value_edges/20),
+#'   size = ceiling(value_edges / 20),
 #'   stringsAsFactors = FALSE
 #' )
 #'
@@ -1138,6 +1121,27 @@ e_sankey.echarts4rProxy <- function(e, source, target, value, layout = "none", r
 #'   e_graph_gl() |>
 #'   e_graph_nodes(nodes, name, value, size, grp) |>
 #'   e_graph_edges(edges, source, target)
+#'
+#' # Fixed node positions
+#' nodes <- data.frame(
+#'   name = c("A", "B", "C", "D", "E"),
+#'   value = c("A", "B", "C", "D", "E"),
+#'   group = c("gr1", "gr1", "gr2", "gr2", "gr3"),
+#'   size = 3:7 * 10,
+#'   x = c(0, 200, 400, 600, 800),
+#'   y = c(100, 100, 200, 200, 0)
+#' )
+#'
+#' edges <- data.frame(
+#'   source = c("A", "B", "C", "D", "E"),
+#'   target = c("B", "C", "D", "E", "D")
+#' )
+#'
+#' e_charts() |>
+#'   e_graph(layout = "none", autoCurveness = TRUE) |>
+#'   e_graph_nodes(nodes, name, value, size, category = group, xpos = x, ypos = y) |>
+#'   e_graph_edges(edges, source, target) |>
+#'   e_tooltip()
 #' @seealso \href{https://echarts.apache.org/en/option.html#series-graph}{Additional arguments},
 #'  \code{\link{e_modularity}}
 #'
@@ -1363,20 +1367,20 @@ e_graph_edges.echarts4r <- function(e, edges, source, target, value, size) {
   if (missing(edges) || missing(source) || missing(target)) {
     stop("must pass edges, source and target", call. = FALSE)
   }
-  
+
   if (missing(size)) {
     size <- NULL
   }
-  
+
   if (missing(value)) {
     value <- NULL
   }
-  
+
   source <- dplyr::enquo(source)
   target <- dplyr::enquo(target)
   value <- dplyr::enquo(value)
   size <- dplyr::enquo(size)
-  
+
   data <- .build_graph_edges(
     edges,
     source,
@@ -1397,16 +1401,16 @@ e_graph_edges.echarts4rProxy <- function(e, edges, source, target, value, size) 
   if (missing(edges) || missing(source) || missing(target)) {
     stop("must pass edges, source and target", call. = FALSE)
   }
-  
+
   if (missing(size)) {
     size <- NULL
   }
-  
+
   source <- dplyr::enquo(source)
   target <- dplyr::enquo(target)
   value <- dplyr::enquo(value)
   size <- dplyr::enquo(size)
-  
+
   data <- .build_graph_edges(
     edges,
     source,
@@ -1513,34 +1517,32 @@ e_graph_edges.echarts4rProxy <- function(e, edges, source, target, value, size) 
 #' @rdname e_heatmap
 #' @export
 e_heatmap <- function(
-  e,
-  y,
-  z,
-  bind,
-  name = NULL,
-  coord_system = "cartesian2d",
-  rm_x = TRUE,
-  rm_y = TRUE,
-  calendar = NULL,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    name = NULL,
+    coord_system = "cartesian2d",
+    rm_x = TRUE,
+    rm_y = TRUE,
+    calendar = NULL,
+    ...) {
   UseMethod("e_heatmap")
 }
 
 #' @export
 #' @method e_heatmap echarts4r
 e_heatmap.echarts4r <- function(
-  e,
-  y,
-  z,
-  bind,
-  name = NULL,
-  coord_system = "cartesian2d",
-  rm_x = TRUE,
-  rm_y = TRUE,
-  calendar = NULL,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    name = NULL,
+    coord_system = "cartesian2d",
+    rm_x = TRUE,
+    rm_y = TRUE,
+    calendar = NULL,
+    ...) {
   if (missing(y)) {
     stop("must pass y", call. = FALSE)
   }
@@ -1563,17 +1565,16 @@ e_heatmap.echarts4r <- function(
 #' @export
 #' @method e_heatmap echarts4rProxy
 e_heatmap.echarts4rProxy <- function(
-  e,
-  y,
-  z,
-  bind,
-  name = NULL,
-  coord_system = "cartesian2d",
-  rm_x = TRUE,
-  rm_y = TRUE,
-  calendar = NULL,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    name = NULL,
+    coord_system = "cartesian2d",
+    rm_x = TRUE,
+    rm_y = TRUE,
+    calendar = NULL,
+    ...) {
   if (missing(y)) {
     stop("must pass y", call. = FALSE)
   }
@@ -1684,7 +1685,7 @@ e_parallel.echarts4rProxy <- function(e, ..., name = NULL, rm_x = TRUE, rm_y = T
 #' @examples
 #' mtcars |>
 #'   head() |>
-#'   tibble::rownames_to_column("model") |> 
+#'   tibble::rownames_to_column("model") |>
 #'   e_charts(model) |>
 #'   e_pie(carb)
 #'
@@ -2039,9 +2040,9 @@ e_boxplot.echarts4rProxy <- function(e, serie, name = NULL, outliers = TRUE, ...
 #'           children = list(
 #'             tibble(
 #'               name = c("shark", "tuna")
-#'               ),
-#'               # 4th level
-#'               NULL # kelp
+#'             ),
+#'             # 4th level
+#'             NULL # kelp
 #'           )
 #'         )
 #'       )
@@ -2083,15 +2084,15 @@ e_tree.echarts4rProxy <- function(e, rm_x = TRUE, rm_y = TRUE, ...) {
 #' @examples
 #' e_charts() |>
 #'   e_gauge(57, "PERCENT")
-#' 
-#' # timeline 
-#' data.frame(time = 2015:2017) |> 
-#'   group_by(time) |> 
+#'
+#' # timeline
+#' data.frame(time = 2015:2017) |>
+#'   group_by(time) |>
 #'   e_charts(timeline = TRUE) |>
-#'     e_gauge(
-#'       c(57, 23, 65),
-#'       c("percent", "percentage", "cases")
-#'     )
+#'   e_gauge(
+#'     c(57, 23, 65),
+#'     c("percent", "percentage", "cases")
+#'   )
 #' @seealso \href{https://echarts.apache.org/en/option.html#series-gauge}{Additional arguments}
 #'
 #' @rdname e_gauge
@@ -2105,8 +2106,9 @@ e_gauge.echarts4r <- function(e, value, name, rm_x = TRUE, rm_y = TRUE, ...) {
     stop("missing e, name, or value", call. = FALSE)
   }
 
-  if (!inherits(value, "numeric"))
+  if (!inherits(value, "numeric")) {
     stop("must pass numeric or integer", call. = FALSE)
+  }
 
   # remove axis
   e <- .rm_axis(e, rm_x, "x")
@@ -2130,7 +2132,7 @@ e_gauge.echarts4r <- function(e, value, name, rm_x = TRUE, rm_y = TRUE, ...) {
     }
   }
 
-  if(e$x$tl){
+  if (e$x$tl) {
     e$x$opts$baseOption$series <- append(e$x$opts$baseOption$series, list(opts))
   }
   e
@@ -2165,7 +2167,7 @@ e_gauge_ <- function(e, value, name, rm_x = TRUE, rm_y = TRUE, ...) {
     v <- .get_data(e, value, i = i) |>
       unlist() |>
       unname()
-    
+
     values[[i]] <- v[[1]]
 
     serie <- list(
@@ -2284,40 +2286,38 @@ e_gauge_ <- function(e, value, name, rm_x = TRUE, rm_y = TRUE, ...) {
 #' @rdname line3D
 #' @export
 e_lines_3d <- function(
-  e,
-  source_lon,
-  source_lat,
-  target_lon,
-  target_lat,
-  source_name,
-  target_name,
-  value,
-  name = NULL,
-  coord_system = "globe",
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    source_lon,
+    source_lat,
+    target_lon,
+    target_lat,
+    source_name,
+    target_name,
+    value,
+    name = NULL,
+    coord_system = "globe",
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   UseMethod("e_lines_3d")
 }
 
 #' @export
 #' @method e_lines_3d echarts4r
 e_lines_3d.echarts4r <- function(
-  e,
-  source_lon,
-  source_lat,
-  target_lon,
-  target_lat,
-  source_name,
-  target_name,
-  value,
-  name = NULL,
-  coord_system = "globe",
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    source_lon,
+    source_lat,
+    target_lon,
+    target_lat,
+    source_name,
+    target_name,
+    value,
+    name = NULL,
+    coord_system = "globe",
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon)) {
     stop("missing coordinates", call. = FALSE)
   }
@@ -2360,20 +2360,19 @@ e_lines_3d.echarts4r <- function(
 #' @export
 #' @method e_lines_3d echarts4rProxy
 e_lines_3d.echarts4rProxy <- function(
-  e,
-  source_lon,
-  source_lat,
-  target_lon,
-  target_lat,
-  source_name,
-  target_name,
-  value,
-  name = NULL,
-  coord_system = "globe",
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    source_lon,
+    source_lat,
+    target_lon,
+    target_lat,
+    source_name,
+    target_name,
+    value,
+    name = NULL,
+    coord_system = "globe",
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(source_lat) || missing(source_lon) || missing(target_lat) || missing(target_lon)) {
     stop("missing coordinates", call. = FALSE)
   }
@@ -2542,32 +2541,30 @@ e_line_3d.echarts4rProxy <- function(e, y, z, name = NULL, coord_system = NULL, 
 #' @rdname e_bar_3d
 #' @export
 e_bar_3d <- function(
-  e,
-  y,
-  z,
-  bind,
-  coord_system = "cartesian3D",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    coord_system = "cartesian3D",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   UseMethod("e_bar_3d")
 }
 
 #' @export
 #' @method e_bar_3d echarts4r
 e_bar_3d.echarts4r <- function(
-  e,
-  y,
-  z,
-  bind,
-  coord_system = "cartesian3D",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    coord_system = "cartesian3D",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(y) || missing(z)) {
     stop("must pass y and z", call. = FALSE)
   }
@@ -2594,16 +2591,15 @@ e_bar_3d.echarts4r <- function(
 #' @export
 #' @method e_bar_3d echarts4rProxy
 e_bar_3d.echarts4rProxy <- function(
-  e,
-  y,
-  z,
-  bind,
-  coord_system = "cartesian3D",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    coord_system = "cartesian3D",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(y) || missing(z)) {
     stop("must pass y and z", call. = FALSE)
   }
@@ -2651,30 +2647,28 @@ e_bar_3d.echarts4rProxy <- function(
 #' @rdname e_surface
 #' @export
 e_surface <- function(
-  e,
-  y,
-  z,
-  bind,
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   UseMethod("e_surface")
 }
 
 #' @export
 #' @method e_surface echarts4r
 e_surface.echarts4r <- function(
-  e,
-  y,
-  z,
-  bind,
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -2704,15 +2698,14 @@ e_surface.echarts4r <- function(
 #' @export
 #' @method e_surface echarts4rProxy
 e_surface.echarts4rProxy <- function(
-  e,
-  y,
-  z,
-  bind,
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    y,
+    z,
+    bind,
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -2806,40 +2799,38 @@ e_surface.echarts4rProxy <- function(
 #' @rdname e_lines
 #' @export
 e_lines <- function(
-  e,
-  source_lon,
-  source_lat,
-  target_lon,
-  target_lat,
-  source_name,
-  target_name,
-  value,
-  coord_system = "geo",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    source_lon,
+    source_lat,
+    target_lon,
+    target_lat,
+    source_name,
+    target_name,
+    value,
+    coord_system = "geo",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   UseMethod("e_lines")
 }
 
 #' @export
 #' @method e_lines echarts4r
 e_lines.echarts4r <- function(
-  e,
-  source_lon,
-  source_lat,
-  target_lon,
-  target_lat,
-  source_name,
-  target_name,
-  value,
-  coord_system = "geo",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    source_lon,
+    source_lat,
+    target_lon,
+    target_lat,
+    source_name,
+    target_name,
+    value,
+    coord_system = "geo",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -2886,20 +2877,19 @@ e_lines.echarts4r <- function(
 #' @export
 #' @method e_lines echarts4rProxy
 e_lines.echarts4rProxy <- function(
-  e,
-  source_lon,
-  source_lat,
-  target_lon,
-  target_lat,
-  source_name,
-  target_name,
-  value,
-  coord_system = "geo",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  ...
-) {
+    e,
+    source_lon,
+    source_lat,
+    target_lon,
+    target_lat,
+    source_name,
+    target_name,
+    value,
+    coord_system = "geo",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -3017,38 +3007,36 @@ e_lines.echarts4rProxy <- function(
 #' @rdname e_scatter_3d
 #' @export
 e_scatter_3d <- function(
-  e,
-  y,
-  z,
-  color,
-  size,
-  bind,
-  coord_system = "cartesian3D",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  legend = FALSE,
-  ...
-) {
+    e,
+    y,
+    z,
+    color,
+    size,
+    bind,
+    coord_system = "cartesian3D",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    legend = FALSE,
+    ...) {
   UseMethod("e_scatter_3d")
 }
 
 #' @export
 #' @method e_scatter_3d echarts4r
 e_scatter_3d.echarts4r <- function(
-  e,
-  y,
-  z,
-  color,
-  size,
-  bind,
-  coord_system = "cartesian3D",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  legend = FALSE,
-  ...
-) {
+    e,
+    y,
+    z,
+    color,
+    size,
+    bind,
+    coord_system = "cartesian3D",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    legend = FALSE,
+    ...) {
   if (missing(y) || missing(z)) {
     stop("must pass y and z", call. = FALSE)
   }
@@ -3090,19 +3078,18 @@ e_scatter_3d.echarts4r <- function(
 #' @export
 #' @method e_scatter_3d echarts4rProxy
 e_scatter_3d.echarts4rProxy <- function(
-  e,
-  y,
-  z,
-  color,
-  size,
-  bind,
-  coord_system = "cartesian3D",
-  name = NULL,
-  rm_x = TRUE,
-  rm_y = TRUE,
-  legend = FALSE,
-  ...
-) {
+    e,
+    y,
+    z,
+    color,
+    size,
+    bind,
+    coord_system = "cartesian3D",
+    name = NULL,
+    rm_x = TRUE,
+    rm_y = TRUE,
+    legend = FALSE,
+    ...) {
   if (missing(y) || missing(z)) {
     stop("must pass y and z", call. = FALSE)
   }
@@ -3599,8 +3586,9 @@ e_lm <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth
 e_lm.echarts4r <- function(e, formula, name = NULL, legend = TRUE, symbol = "none", smooth = TRUE, model_args = list(), ...) {
   form <- as.formula(formula)
 
-  if(!is.null(name) && length(name) != length(e$x$data))
+  if (!is.null(name) && length(name) != length(e$x$data)) {
     stop("More groups than names", call. = FALSE)
+  }
 
   for (i in seq_along(e$x$data)) {
     e$x$data[[i]] <- e$x$data[[i]][stats::complete.cases(e$x$data[[i]]), ]
@@ -3875,17 +3863,16 @@ e_glm.echarts4rProxy <- function(e, formula, name = NULL, legend = TRUE, symbol 
 #' @rdname smooth
 #' @export
 e_loess <- function(
-  e,
-  formula,
-  name = NULL,
-  legend = TRUE,
-  symbol = "none",
-  smooth = TRUE,
-  x_index = 0,
-  y_index = 0,
-  model_args = list(),
-  ...
-) {
+    e,
+    formula,
+    name = NULL,
+    legend = TRUE,
+    symbol = "none",
+    smooth = TRUE,
+    x_index = 0,
+    y_index = 0,
+    model_args = list(),
+    ...) {
   UseMethod("e_loess")
 }
 
@@ -3893,17 +3880,16 @@ e_loess <- function(
 #' @method e_loess echarts4r
 #' @importFrom stats complete.cases
 e_loess.echarts4r <- function(
-  e,
-  formula,
-  name = NULL,
-  legend = TRUE,
-  symbol = "none",
-  smooth = TRUE,
-  x_index = 0,
-  y_index = 0,
-  model_args = list(),
-  ...
-) {
+    e,
+    formula,
+    name = NULL,
+    legend = TRUE,
+    symbol = "none",
+    smooth = TRUE,
+    x_index = 0,
+    y_index = 0,
+    model_args = list(),
+    ...) {
   for (i in seq_along(e$x$data)) {
     e$x$data[[i]] <- e$x$data[[i]][stats::complete.cases(e$x$data[[i]]), ]
 
@@ -3981,17 +3967,16 @@ e_loess.echarts4r <- function(
 #' @method e_loess echarts4rProxy
 #' @importFrom stats complete.cases
 e_loess.echarts4rProxy <- function(
-  e,
-  formula,
-  name = NULL,
-  legend = TRUE,
-  symbol = "none",
-  smooth = TRUE,
-  x_index = 0,
-  y_index = 0,
-  model_args = list(),
-  ...
-) {
+    e,
+    formula,
+    name = NULL,
+    legend = TRUE,
+    symbol = "none",
+    smooth = TRUE,
+    x_index = 0,
+    y_index = 0,
+    model_args = list(),
+    ...) {
   for (i in seq_along(e$chart$x$data)) {
     e$chart$x$data[[i]] <- e$chart$x$data[[i]][stats::complete.cases(e$chart$x$data[[i]]), ]
 
@@ -4093,32 +4078,30 @@ e_loess.echarts4rProxy <- function(
 #' @rdname histogram
 #' @export
 e_histogram <- function(
-  e,
-  serie,
-  breaks = "Sturges",
-  name = NULL,
-  legend = TRUE,
-  bar_width = "99%",
-  x_index = 0,
-  y_index = 0,
-  ...
-) {
+    e,
+    serie,
+    breaks = "Sturges",
+    name = NULL,
+    legend = TRUE,
+    bar_width = "99%",
+    x_index = 0,
+    y_index = 0,
+    ...) {
   UseMethod("e_histogram")
 }
 
 #' @export
 #' @method e_histogram echarts4r
 e_histogram.echarts4r <- function(
-  e,
-  serie,
-  breaks = "Sturges",
-  name = NULL,
-  legend = TRUE,
-  bar_width = "99%",
-  x_index = 0,
-  y_index = 0,
-  ...
-) {
+    e,
+    serie,
+    breaks = "Sturges",
+    name = NULL,
+    legend = TRUE,
+    bar_width = "99%",
+    x_index = 0,
+    y_index = 0,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4133,16 +4116,15 @@ e_histogram.echarts4r <- function(
 #' @export
 #' @method e_histogram echarts4rProxy
 e_histogram.echarts4rProxy <- function(
-  e,
-  serie,
-  breaks = "Sturges",
-  name = NULL,
-  legend = TRUE,
-  bar_width = "99%",
-  x_index = 0,
-  y_index = 0,
-  ...
-) {
+    e,
+    serie,
+    breaks = "Sturges",
+    name = NULL,
+    legend = TRUE,
+    bar_width = "99%",
+    x_index = 0,
+    y_index = 0,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4158,32 +4140,30 @@ e_histogram.echarts4rProxy <- function(
 #' @rdname histogram
 #' @export
 e_density <- function(
-  e,
-  serie,
-  breaks = "Sturges",
-  name = NULL,
-  legend = TRUE,
-  x_index = 0,
-  y_index = 0,
-  smooth = TRUE,
-  ...
-) {
+    e,
+    serie,
+    breaks = "Sturges",
+    name = NULL,
+    legend = TRUE,
+    x_index = 0,
+    y_index = 0,
+    smooth = TRUE,
+    ...) {
   UseMethod("e_density")
 }
 
 #' @export
 #' @method e_density echarts4r
 e_density.echarts4r <- function(
-  e,
-  serie,
-  breaks = "Sturges",
-  name = NULL,
-  legend = TRUE,
-  x_index = 0,
-  y_index = 0,
-  smooth = TRUE,
-  ...
-) {
+    e,
+    serie,
+    breaks = "Sturges",
+    name = NULL,
+    legend = TRUE,
+    x_index = 0,
+    y_index = 0,
+    smooth = TRUE,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4198,16 +4178,15 @@ e_density.echarts4r <- function(
 #' @export
 #' @method e_density echarts4rProxy
 e_density.echarts4rProxy <- function(
-  e,
-  serie,
-  breaks = "Sturges",
-  name = NULL,
-  legend = TRUE,
-  x_index = 0,
-  y_index = 0,
-  smooth = TRUE,
-  ...
-) {
+    e,
+    serie,
+    breaks = "Sturges",
+    name = NULL,
+    legend = TRUE,
+    x_index = 0,
+    y_index = 0,
+    smooth = TRUE,
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4297,30 +4276,28 @@ e_lines_gl.echarts4rProxy <- function(e, data, coord_system = "geo", ...) {
 #' @name band
 #' @export
 e_band <- function(
-  e,
-  min,
-  max,
-  stack = "confidence-band",
-  symbol = c("none", "none"),
-  areaStyle = list(list(color = "rgba(0,0,0,0)"), list()),
-  legend = list(FALSE, FALSE),
-  ...
-) {
+    e,
+    min,
+    max,
+    stack = "confidence-band",
+    symbol = c("none", "none"),
+    areaStyle = list(list(color = "rgba(0,0,0,0)"), list()),
+    legend = list(FALSE, FALSE),
+    ...) {
   UseMethod("e_band")
 }
 
 #' @export
 #' @method e_band echarts4r
 e_band.echarts4r <- function(
-  e,
-  min,
-  max,
-  stack = "confidence-band",
-  symbol = c("none", "none"),
-  areaStyle = list(list(color = "rgba(0,0,0,0)"), list()),
-  legend = list(FALSE, FALSE),
-  ...
-) {
+    e,
+    min,
+    max,
+    stack = "confidence-band",
+    symbol = c("none", "none"),
+    areaStyle = list(list(color = "rgba(0,0,0,0)"), list()),
+    legend = list(FALSE, FALSE),
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4344,15 +4321,14 @@ e_band.echarts4r <- function(
 #' @export
 #' @method e_band echarts4rProxy
 e_band.echarts4rProxy <- function(
-  e,
-  min,
-  max,
-  stack = "confidence-band",
-  symbol = c("none", "none"),
-  areaStyle = list(list(color = "rgba(0,0,0,0)"), list()),
-  legend = list(FALSE, FALSE),
-  ...
-) {
+    e,
+    min,
+    max,
+    stack = "confidence-band",
+    symbol = c("none", "none"),
+    areaStyle = list(list(color = "rgba(0,0,0,0)"), list()),
+    legend = list(FALSE, FALSE),
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4492,32 +4468,30 @@ e_correlations.echarts4rProxy <- function(e, order = NULL, visual_map = TRUE, ..
 #' @rdname errorbar
 #' @export
 e_error_bar <- function(
-  e,
-  lower,
-  upper,
-  name = NULL,
-  legend = FALSE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    lower,
+    upper,
+    name = NULL,
+    legend = FALSE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   UseMethod("e_error_bar")
 }
 
 #' @export
 #' @method e_error_bar echarts4r
 e_error_bar.echarts4r <- function(
-  e,
-  lower,
-  upper,
-  name = NULL,
-  legend = FALSE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    lower,
+    upper,
+    name = NULL,
+    legend = FALSE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }
@@ -4542,16 +4516,15 @@ e_error_bar.echarts4r <- function(
 #' @export
 #' @method e_error_bar echarts4rProxy
 e_error_bar.echarts4rProxy <- function(
-  e,
-  lower,
-  upper,
-  name = NULL,
-  legend = FALSE,
-  y_index = 0,
-  x_index = 0,
-  coord_system = "cartesian2d",
-  ...
-) {
+    e,
+    lower,
+    upper,
+    name = NULL,
+    legend = FALSE,
+    y_index = 0,
+    x_index = 0,
+    coord_system = "cartesian2d",
+    ...) {
   if (missing(e)) {
     stop("must pass e", call. = FALSE)
   }

--- a/R/add.R
+++ b/R/add.R
@@ -1236,11 +1236,11 @@ e_graph_gl.echarts4rProxy <- function(e, layout = "force", name = NULL, rm_x = T
 
 #' @rdname graph
 #' @export
-e_graph_nodes <- function(e, nodes, names, value, size, category, symbol = NULL, legend = TRUE) UseMethod("e_graph_nodes")
+e_graph_nodes <- function(e, nodes, names, value, size, category, symbol = NULL, legend = TRUE, xpos = NULL, ypos = NULL) UseMethod("e_graph_nodes")
 
 #' @export
 #' @method e_graph_nodes echarts4r
-e_graph_nodes.echarts4r <- function(e, nodes, names, value, size, category, symbol = NULL, legend = TRUE) {
+e_graph_nodes.echarts4r <- function(e, nodes, names, value, size, category, symbol = NULL, legend = TRUE, xpos = NULL, ypos = NULL) {
   if (missing(nodes) || missing(names) || missing(value)) {
     stop("missing arguments", call. = FALSE)
   }
@@ -1249,6 +1249,9 @@ e_graph_nodes.echarts4r <- function(e, nodes, names, value, size, category, symb
   symbolSize <- dplyr::enquo(size)
   symbol <- dplyr::enquo(symbol)
   names <- dplyr::enquo(names)
+  xpos <- dplyr::enquo(xpos)
+  ypos <- dplyr::enquo(ypos)
+
 
   if (!missing(category) && !missing(size)) {
     e$x$opts$series[[length(e$x$opts$series)]]$categories <- .build_graph_category(nodes, dplyr::enquo(category))
@@ -1263,7 +1266,9 @@ e_graph_nodes.echarts4r <- function(e, nodes, names, value, size, category, symb
       value,
       symbolSize,
       dplyr::enquo(category),
-      symbol
+      symbol,
+      xpos,
+      ypos
     )
   } else if (missing(category) && !missing(size)) {
     nodes <- .build_graph_nodes_no_cat(
@@ -1271,14 +1276,18 @@ e_graph_nodes.echarts4r <- function(e, nodes, names, value, size, category, symb
       names,
       value,
       symbolSize,
-      symbol
+      symbol,
+      xpos,
+      ypos
     )
   } else if (missing(category) && missing(size)) {
     nodes <- .build_graph_nodes_no_size(
       nodes,
       names,
       value,
-      symbol
+      symbol,
+      xpos,
+      ypos
     )
   }
 
@@ -1289,7 +1298,7 @@ e_graph_nodes.echarts4r <- function(e, nodes, names, value, size, category, symb
 
 #' @export
 #' @method e_graph_nodes echarts4rProxy
-e_graph_nodes.echarts4rProxy <- function(e, nodes, names, value, size, category, symbol = NULL, legend = TRUE) {
+e_graph_nodes.echarts4rProxy <- function(e, nodes, names, value, size, category, symbol = NULL, legend = TRUE, xpos = NULL, ypos = NULL) {
   if (missing(nodes) || missing(names) || missing(value)) {
     stop("missing arguments", call. = FALSE)
   }
@@ -1298,6 +1307,8 @@ e_graph_nodes.echarts4rProxy <- function(e, nodes, names, value, size, category,
   symbolSize <- dplyr::enquo(size)
   symbol <- dplyr::enquo(symbol)
   names <- dplyr::enquo(names)
+  xpos <- dplyr::enquo(xpos)
+  ypos <- dplyr::enquo(ypos)
 
   if (!missing(category) && !missing(size)) {
     e$chart$x$opts$series[[length(e$chart$x$opts$series)]]$categories <- .build_graph_category(nodes, dplyr::enquo(category))
@@ -1312,7 +1323,9 @@ e_graph_nodes.echarts4rProxy <- function(e, nodes, names, value, size, category,
       value,
       symbolSize,
       symbol,
-      dplyr::enquo(category)
+      dplyr::enquo(category),
+      xpos,
+      ypos
     )
   } else if (missing(category) && !missing(size)) {
     nodes <- .build_graph_nodes_no_cat(
@@ -1320,14 +1333,18 @@ e_graph_nodes.echarts4rProxy <- function(e, nodes, names, value, size, category,
       names,
       value,
       symbolSize,
-      symbol
+      symbol,
+      xpos,
+      ypos
     )
   } else if (missing(category) && missing(size)) {
     nodes <- .build_graph_nodes_no_size(
       nodes,
       names,
       value,
-      symbol
+      symbol,
+      xpos,
+      ypos
     )
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
   vect <- data[[x]]
 
   if (reorder) {
-    if (any(c(inherits(vect, "numeric"),inherits(vect, "integer")))) {
+    if (any(c(inherits(vect, "numeric"), inherits(vect, "integer")))) {
       data <- data[order(data[[x]]), ]
     }
   }
@@ -66,8 +66,8 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
 }
 
 .build_data <- function(e, ...) {
-  data <- e$x$data[[1]]  |>
-     dplyr::select(...)
+  data <- e$x$data[[1]] |>
+    dplyr::select(...)
   # data <- data[, c(...), drop = FALSE]
   data <- unname(data)
 
@@ -104,7 +104,7 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
       x = .jitter(x, factor, amount),
       y = .jitter(y, factor, amount)
     )
-  
+
   data <- unname(data)
 
   apply(data, 1, function(x) {
@@ -114,15 +114,15 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
 
 .build_data_jitter <- function(data, x, y, factor = 0, amount = NULL) {
   row.names(data) <- NULL
-  
+
   data <- data |>
     dplyr::select(x = x, y = y) |>
     dplyr::mutate(
       x = .jitter(x, factor, amount),
       y = .jitter(y, factor, amount)
-    ) 
-    
-    data <- unname(data)
+    )
+
+  data <- unname(data)
 
   apply(data, 1, function(x) {
     list(value = unlist(x, use.names = FALSE))
@@ -212,92 +212,89 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
   apply(edges, 1, as.list)
 }
 
-.build_graph_nodes <- function(nodes, names, value, symbolSize, category, symbol) {
+.build_graph_nodes <- function(nodes, names, value, symbolSize, category, symbol, xpos, ypos) {
   row.names(nodes) <- NULL
 
-  nodes |>
+  data <- nodes |>
     dplyr::select(
-      !!names,
-      !!value,
-      !!symbolSize,
-      !!category,
-      !!symbol,
-    ) -> data
-
-  names(data) <- c("name", "value", "symbolSize", "category", "symbol")[1:ncol(data)]
+      name = !!names,
+      value = !!value,
+      symbolSize = !!symbolSize,
+      category = !!category,
+      symbol = !!symbol,
+      x = !!xpos,
+      y = !!ypos
+    )
 
   apply(data, 1, as.list)
 }
 
-.build_graph_nodes_no_size <- function(nodes, names, value, symbol) {
+.build_graph_nodes_no_size <- function(nodes, names, value, symbol, xpos, ypos) {
   row.names(nodes) <- NULL
 
-  nodes |>
+  data <- nodes |>
     dplyr::select(
-      !!names,
-      !!value,
-      !!symbol,
-    ) -> data
-
-  names(data) <- c("name", "value", "symbol")[1:ncol(data)]
+      name = !!names,
+      value = !!value,
+      symbol = !!symbol,
+      x = !!xpos,
+      y = !!ypos
+    )
 
   apply(data, 1, as.list)
 }
 
-.build_graph_nodes_no_cat <- function(nodes, names, value, symbolSize, symbol) {
+.build_graph_nodes_no_cat <- function(nodes, names, value, symbolSize, symbol, xpos, ypos) {
   row.names(nodes) <- NULL
 
-  nodes |>
+  data <- nodes |>
     dplyr::select(
-      !!names,
-      !!value,
-      !!symbolSize,
-      !!symbol
-    ) -> data
-
-  names(data) <- c("name", "value", "symbolSize", "symbol")[1:ncol(data)]
+      name = !!names,
+      value = !!value,
+      symbolSize = !!symbolSize,
+      symbol = !!symbol,
+      x = !!xpos,
+      y = !!ypos
+    )
 
   apply(data, 1, as.list)
 }
 
 .build_graph_edges <- function(edges, source, target, value, size) {
   row.names(edges) <- NULL
-  
+
   if (is.null(size)) {
-    
-    edges |>
+    data <- edges |>
       dplyr::select(
         source = !!source,
         target = !!target,
         value = !!value
-      ) -> data
-    
+      )
+
     x <- apply(data, 1, as.list)
-    
   } else {
-    
-    edges |>
+    data <- edges |>
       dplyr::select(
         source = !!source,
         target = !!target,
         value = !!value,
         size = !!size
-      ) -> data
-    
+      )
+
     x <- apply(data, 1, function(x) {
       list(
         source = unname(x["source"]),
         target = unname(x["target"]),
-        value = {if (is.null(value)) "" else unname(x["value"])},
+        value = {
+          if (is.null(value)) "" else unname(x["value"])
+        },
         symbolSize = c(5, 20),
         lineStyle = list(width = unname(x["size"]))
       )
     })
-    
   }
-  
+
   x
-  
 }
 
 .build_graph_category <- function(nodes, cat) {
@@ -374,7 +371,6 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
 #' @noRd
 #' @keywords internal
 .build_sun <- function(e, styles = NULL, names = NULL, levels = NULL) {
-
   #' recursive json-list traversal, append style on matching level and/or name
   recu <- function(chld, level) {
     if (!is.null(levels)) {
@@ -456,7 +452,7 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
   data <- e$x$data[[i]] |>
     dplyr::select(serie) |>
     unname()
-  
+
   data[[1]]
 }
 
@@ -576,7 +572,6 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
 
 
 .build_height <- function(e, serie, color, j) {
-
   # data <- .build_data(e, e$x$mapping$x, serie, names = c("name", "height"))
   e$x$data[[j]] |>
     dplyr::select(
@@ -695,8 +690,7 @@ globalVariables(c("x", "e", ".", "acc", "epoch", "loss", "size", "val_acc", "val
     if (length(e$x$opts$graphic) == 0) {
       e$x$opts$graphic <- list(...)
     }
-  } else
-  if (length(e$x$opts$baseOption$graphic) == 0) {
+  } else if (length(e$x$opts$baseOption$graphic) == 0) {
     e$x$opts$baseOption$graphic <- list(...)
   }
 

--- a/man/e_bar.Rd
+++ b/man/e_bar.Rd
@@ -52,7 +52,7 @@ Add bar serie.
 }
 \note{
 The bar serie expects the data on the x axis to be
-\code{categorical} in R this means a \code{factor} or 
+\code{categorical} in R this means a \code{factor} or
 \code{character}. If the data on the x axis is numeric
 everything should work well in most cases but strange
 behaviour may be observed.
@@ -61,7 +61,7 @@ behaviour may be observed.
 library(dplyr)
 
 mtcars |>
-  tibble::rownames_to_column("model") |> 
+  tibble::rownames_to_column("model") |>
   mutate(total = mpg + qsec) |>
   arrange(desc(total)) |>
   e_charts(model) |>

--- a/man/e_gauge.Rd
+++ b/man/e_gauge.Rd
@@ -28,14 +28,14 @@ Plot a gauge.
 e_charts() |>
   e_gauge(57, "PERCENT")
 
-# timeline 
-data.frame(time = 2015:2017) |> 
-  group_by(time) |> 
+# timeline
+data.frame(time = 2015:2017) |>
+  group_by(time) |>
   e_charts(timeline = TRUE) |>
-    e_gauge(
-      c(57, 23, 65),
-      c("percent", "percentage", "cases")
-    )
+  e_gauge(
+    c(57, 23, 65),
+    c("percent", "percentage", "cases")
+  )
 }
 \seealso{
 \href{https://echarts.apache.org/en/option.html#series-gauge}{Additional arguments}

--- a/man/e_pie.Rd
+++ b/man/e_pie.Rd
@@ -29,7 +29,7 @@ Draw pie and donut charts.
 \examples{
 mtcars |>
   head() |>
-  tibble::rownames_to_column("model") |> 
+  tibble::rownames_to_column("model") |>
   e_charts(model) |>
   e_pie(carb)
 

--- a/man/e_step.Rd
+++ b/man/e_step.Rd
@@ -60,7 +60,7 @@ Add step serie.
 }
 \examples{
 USArrests |>
-  tibble::rownames_to_column("State") |> 
+  tibble::rownames_to_column("State") |>
   e_charts(State) |>
   e_step(Murder, name = "Start", step = "start", fill = TRUE) |>
   e_step(Rape, name = "Middle", step = "middle") |>

--- a/man/e_tree.Rd
+++ b/man/e_tree.Rd
@@ -37,9 +37,9 @@ df <- tibble(
           children = list(
             tibble(
               name = c("shark", "tuna")
-              ),
-              # 4th level
-              NULL # kelp
+            ),
+            # 4th level
+            NULL # kelp
           )
         )
       )

--- a/man/echarts4r-shiny.Rd
+++ b/man/echarts4r-shiny.Rd
@@ -54,12 +54,23 @@ is useful if you want to save an expression in a variable.}
 
 \item{session}{Shiny session.}
 
-\item{reorder}{Set the \code{FALSE} to not reorder numeric x axis values.}
+\item{reorder}{Set to \code{FALSE} to not reorder numeric x axis values.}
 }
 \description{
 Output and render functions for using echarts4r within Shiny
 applications and interactive Rmd documents.
 }
+\section{Details}{
+ The chart is created inside a parent \code{'<div>'}
+  element, the dimensions of which are controlled by the \code{'width'} and
+  \code{'height'} arguments. When these dimensions are small, it is possible
+  that the chart \code{'grid'} resizes to a size larger than the parent,
+  which might result in unexpected size given the input arguments. To disable
+  this automatic readjustment, define a static \code{\link{e_grid}} like the
+  following: \code{'e_grid(e = current_chart, top = 0, left = 20, right = 0,
+  bottom = 20)'}.
+}
+
 \section{Callbacks}{
 
 \itemize{

--- a/man/graph.Rd
+++ b/man/graph.Rd
@@ -27,7 +27,9 @@ e_graph_nodes(
   size,
   category,
   symbol = NULL,
-  legend = TRUE
+  legend = TRUE,
+  xpos = NULL,
+  ypos = NULL
 )
 
 e_graph_edges(e, edges, source, target, value, size)
@@ -60,6 +62,8 @@ graph but is only necessary for GL.}
 
 \item{legend}{Whether to add serie to legend.}
 
+\item{xpos, ypos}{X and Y coordinates for nodes. Valid when \code{layout = "none"}}
+
 \item{edges}{Data.frame of edges.}
 
 \item{source, target}{Column names of source and target.}
@@ -84,7 +88,7 @@ edges <- data.frame(
   source = sample(nodes$name, 20, replace = TRUE),
   target = sample(nodes$name, 20, replace = TRUE),
   value = value_edges,
-  size = ceiling(value_edges/20),
+  size = ceiling(value_edges / 20),
   stringsAsFactors = FALSE
 )
 
@@ -113,6 +117,27 @@ e_charts() |>
   e_graph_gl() |>
   e_graph_nodes(nodes, name, value, size, grp) |>
   e_graph_edges(edges, source, target)
+
+# Fixed node positions
+nodes <- data.frame(
+  name = c("A", "B", "C", "D", "E"),
+  value = c("A", "B", "C", "D", "E"),
+  group = c("gr1", "gr1", "gr2", "gr2", "gr3"),
+  size = 3:7 * 10,
+  x = c(0, 200, 400, 600, 800),
+  y = c(100, 100, 200, 200, 0)
+)
+
+edges <- data.frame(
+  source = c("A", "B", "C", "D", "E"),
+  target = c("B", "C", "D", "E", "D")
+)
+
+e_charts() |>
+  e_graph(layout = "none", autoCurveness = TRUE) |>
+  e_graph_nodes(nodes, name, value, size, category = group, xpos = x, ypos = y) |>
+  e_graph_edges(edges, source, target) |>
+  e_tooltip()
 }
 \seealso{
 \href{https://echarts.apache.org/en/option.html#series-graph}{Additional arguments},

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -103,16 +103,27 @@ string and have \code{'px'} appended.}
 
 \item{...}{Any other argument.}
 
-\item{reorder}{Set the \code{FALSE} to not reorder numeric x axis values.}
+\item{reorder}{Set to \code{FALSE} to not reorder numeric x axis values.}
 
 \item{e}{An object of class \code{echarts4r} as returned by \code{e_charts}.}
 }
 \description{
 Initialise a chart.
 }
-\section{Timeline}{
+\section{Details}{
+ The chart is created inside a parent \code{'<div>'}
+  element, the dimensions of which are controlled by the \code{'width'} and
+  \code{'height'} arguments. When these dimensions are small, it is possible
+  that the chart \code{'grid'} resizes to a size larger than the parent,
+  which might result in unexpected size given the input arguments. To disable
+  this automatic readjustment, define a static \code{\link{e_grid}} like the
+  following: \code{'e_grid(e = current_chart, top = 0, left = 20, right = 0,
+  bottom = 20)'}.
+}
 
-The timeline feature currently supports the following chart types.
+\section{Timeline}{
+ The timeline feature currently supports the following
+  chart types.
 \itemize{
   \item{\code{\link{e_bar}}}
   \item{\code{\link{e_line}}}


### PR DESCRIPTION
Hi! I was trying to create a graph similar to this: https://echarts.apache.org/examples/en/editor.html?c=graph-simple, where the user passes X and Y coordinates for the nodes. But, it seems that `e_graph()` does not have this feature. Looks like it does not  render anything when `layout = "none"`. After some poking around, it seemed like there was no way to pass X and Y coordinates, so I tried to implement it by updating the `e_graph_nodes` functions and the associated `.` helpers from `utils.R`. 

With this update, a user can now set fixed node positions with a call like:

```
nn <- data.frame(
    name = c("A", "B", "C", "D", "E"),
    value = c("A", "B", "C", "D", "E"),
    group = c("gr1", "gr1", "gr2", "gr2", "gr3"),
    size = 3:7 * 10,
    x = c(0, 200, 400, 600, 800),
    y = c(100, 100, 200, 200, 0)
)

ee <- data.frame(
    source = c("A", "B", "C", "D", "E"),
    target = c("B", "C", "D", "E", "D")
)

devtools::load_all()
e_charts() |>
    e_graph(layout = "none", autoCurveness = TRUE) |>
    e_graph_nodes(nn, name, value, size, category = group, xpos = x, ypos = y) |>
    e_graph_edges(ee, source, target) |>
    e_tooltip()
```

![image](https://github.com/JohnCoene/echarts4r/assets/2613403/39e0d660-791f-4370-bcc6-3dec77911f73)

