### PR TITLE
Update small typo in grid.R - e_area arguments incorrect

### DIFF
--- a/R/grid.R
+++ b/R/grid.R
@@ -260,7 +260,7 @@ e_axis_formatter <- function(
 #' USArrests |>
 #'   e_charts(UrbanPop) |>
 #'   e_line(Assault, smooth = TRUE) |>
-#'   e_area(Murder, y.index = 1, x.index = 1) |>
+#'   e_area(Murder, y_index = 1, x_index = 1) |>
 #'   e_y_axis(gridIndex = 1) |>
 #'   e_x_axis(gridIndex = 1) |>
 #'   e_grid(height = "40%") |>


### PR DESCRIPTION
What

fix of e_area parameters y.index, x.index -> x_index, y_index in e_grid.R L263

Why 

typo caused plots to render incorrectly 

How 

reverted typo. a cursory glance over some of the rest of the docs suggest the issue is one off
