### PR TITLE
Quickfix docs

### DIFF
--- a/R/opts.R
+++ b/R/opts.R
@@ -1052,10 +1052,10 @@ e_arrange <- function(..., rows = NULL, cols = NULL, width = "xs", title = NULL)
         class = "container-fluid",
         htmltools::tags$head(
           htmltools::tags$link(
-            rel = "stylesheet",
-            href = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css",
-            integrity = "sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO",
-            crossorigin = "anonymous"
+            rel="stylesheet",
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css",
+            integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr",
+            crossorigin="anonymous">
           )
         ),
         htmltools::h3(title),

--- a/R/opts.R
+++ b/R/opts.R
@@ -897,7 +897,6 @@ e_flip_coords <- function(e) {
 #'
 #' @inheritParams e_bar
 #'
-#' @note Do not use \code{e_arrange} in R markdown or Shiny.
 #'
 #' @seealso \href{https://echarts.apache.org/en/option.html#textStyle}{official documentation}
 #'


### PR DESCRIPTION
Hi - I have a pull request to run by you composed of two parts.
The first removes reference to ' do not use e_arrange in shiny' in the e_text_style docs. I dont believe it has any reason to be there.
Secondly, using e_arrange in shiny 'works' somewhat,but not seamlessly. Updating to bs5 (when working with bslib and bs5) seems to work much better. My issue was that _reboot.scss stylesheets were overwriting my custom.css when the bs4 library was imported. Instead of updating the disclaimer erroneously posted in the e_text_style docs, that e_arrange should be avoided in shiny, I updated the cdn to point to bs5.3.3 (jsdeliver). I note stackpath may be going out of business. The classes leveraged from bs4 are the same in bs5.  

If instead better warnings (there are none ) should be inplace and the cdn left as it is, is at you discretion.

Again thank you for your work on this. Best, Aaron.

What 
Update docs and cdn

How 
replace href, sha 

Why
Was causing stylesheet conflicts with unnecessary imports
Also the docs alluded to he problem but were scattered and inconsistent