### PR TITLE
Bug Fix e_stage()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,9 +49,9 @@ Suggests:
   data.tree,
   leaflet
 Depends: R (>= 4.1.0)  
-RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 URL: https://echarts4r.john-coene.com, https://github.com/JohnCoene/echarts4r
 BugReports: https://github.com/JohnCoene/echarts4r/issues/
 LazyData: true
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/R/plugins.R
+++ b/R/plugins.R
@@ -889,7 +889,7 @@ e_stage <- function(e,
         e$x$opts$legend$data <- append(e$x$opts$legend$data, list(name))
       }
 
-      e$x$opts$dataset <- list(source = vector)
+      e$x$opts$dataset <- list(source = vector, sourceHeader = FALSE)
 
     }
     else {

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr]{group_by}}}
+  \item{dplyr}{\code{\link[dplyr:group_by]{group_by()}}}
 }}
 


### PR DESCRIPTION
Fixed e_stage() bug which caused the first line of dataset to be removed. This was caused by POSIXct types getting converted into strings within the json. The Echarts JS was seeing the dataset and expecting the first line to be a header row which is not our expected behavior. Adding sourceHeader = FALSE to the dataset prevents Echarts from doing this issue. This has fixed issue #688 

Also updated roxygen2 to 8.0.0