### PR TITLE
Fix build_data2 bug where col names with same name were not being selected

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -131,6 +131,11 @@ globalVariables(c("x", "e", ".", ".data", "acc", "epoch", "loss", "size", "val_a
 
 .build_data2 <- function(data, ...) {
   row.names(data) <- NULL
+
+  # Noticed an issue via unit test for e_line_3d proxy.
+  # select() selects only 1 match of a col name while base R selects all col names and creates duplicates cols names (i.e. y, y.1, y.2).
+  # So it was building the data incorrectly such that the z value in e_line_3d was not being replaced.
+
   # data <- data |>
   #  dplyr::select(...)
   data <- data[, c(...), drop = FALSE]

--- a/tests/testthat/test-build_data2.R
+++ b/tests/testthat/test-build_data2.R
@@ -30,4 +30,17 @@ test_that("build_data2 creates a list", {
   y <- .build_data2(mtcars, "mpg")
 
   expect_type(y, "list")
+
+  # Expect 1 value
+  expect_equal(y[[1]]$value, 21)
+})
+
+test_that("build_data2 creates a list", {
+  x <- mtcars
+  y <- .build_data2(mtcars, "mpg", "mpg")
+
+  expect_type(y, "list")
+
+  # Expect 2 values bc two cols of the same name were selected
+  expect_equal(y[[1]]$value, c(21, 21))
 })

--- a/tests/testthat/test-chart_types.R
+++ b/tests/testthat/test-chart_types.R
@@ -1514,6 +1514,38 @@ test_that("e_heatmap plot has the good data structure and type", {
   )
 })
 
+test_that("e_heatmap selects correct data when y and z are the same", {
+  set.seed(1)
+
+  v <- LETTERS[1:5]
+
+  matrix <- data.frame(
+    x = sample(v, 5, replace = TRUE),
+    y = sample(v, 5, replace = TRUE),
+    z = rnorm(5, 10, 1),
+    stringsAsFactors = FALSE
+  ) |>
+    dplyr::group_by(x, y) |>
+    dplyr::summarise(z = sum(z), .groups = "drop_last") |>
+    dplyr::ungroup()
+
+  # heatmap uses y,y. This should NOT euqal the previous test.
+  # There was a bug in which if y and z are both the same values, then z will get ignored. Now y and z and both treated as y, for example here.
+  plot <- matrix |>
+    e_charts(x) |>
+    e_heatmap(y, y) |>
+    e_visual_map(z)
+
+  expect_equal(
+    plot$x$opts$series[[1]]$data,
+    list(list(value = c("A", "C", "C")), list(value = c("B", "C", "C")), list(value = c("D", "B", "B")), list(value = c("E", "A", "A")))
+  )
+  expect_equal(
+    plot$x$opts$series[[1]]$type,
+    "heatmap"
+  )
+})
+
 test_that("e_heatmap timeline works", {
 
   set.seed(1)
@@ -3093,7 +3125,7 @@ test_that("e_line_3d.echarts4rProxy plot responds", {
     output$bar <- renderEcharts4r({
       test_data |>
         e_charts(x) |>
-        e_line_3d(y, z)
+        e_scatter_3d(y, z)
     })
 
     observeEvent(input$update, {


### PR DESCRIPTION
`.build_data2` was using dplyr's `select()` and `...`. If multiple columns were selected, only 1 returns. Changed to base R which will return all columns selected, even if multiple columns are selected. This effected unit tests, mainly for 3d functions. Now they all pass. :) I also wrote a unit test for `e_heatmap()` that does catch this bug.

This reprex shows expected behavior is correct!
```
library(shiny)

test_data <- data.frame(
  x = seq(3),
  y = c(1, 3, 9),
  z = c(2, 5, 4)
)

ui <- fluidPage(
              echarts4rOutput("bar"),
              actionButton("update", label = "Update")
          )

server <- function(input, output, session) {

  output$bar <- renderEcharts4r({
    test_data |>
      e_charts(x) |>
      e_scatter_3d(y, z) |>
      e_tooltip()
  })

  observeEvent(input$update, {
    echarts4rProxy("bar",
                            data = test_data,
                            x = x) |>
      e_line_3d(y, z = y) |>
      e_execute()
  })
}

shinyApp(ui = ui, server = server)
```
